### PR TITLE
feat(fastify): use openrouter/free as default AI model

### DIFF
--- a/.github/workflows/api-e2e.yml
+++ b/.github/workflows/api-e2e.yml
@@ -24,6 +24,7 @@ env:
   DATABASE_URL: postgresql://localhost/test
   JWT_SECRET: e2e-jwt-secret-min-32-chars-for-tests
   OPEN_ROUTER_API_KEY: ${{ secrets.OPEN_ROUTER_API_KEY != '' && secrets.OPEN_ROUTER_API_KEY || 'sk-or-v1-dummy-key-for-unit-tests' }}
+  AI_DEFAULT_MODEL: meta-llama/llama-3.3-70b-instruct:free
 
 jobs:
   build-and-test:

--- a/apps/fastify/.env-sample
+++ b/apps/fastify/.env-sample
@@ -1,6 +1,9 @@
 # Required: Open Router API key for AI chat
 OPEN_ROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxx
 
+# Optional: Override default AI model (default: openrouter/free)
+# AI_DEFAULT_MODEL=openrouter/free
+
 # Database (PGLITE=true uses in-memory PGLite; when false, DATABASE_URL is required)
 PGLITE=false
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres

--- a/apps/fastify/.env.test.example
+++ b/apps/fastify/.env.test.example
@@ -5,6 +5,9 @@ DATABASE_URL=postgresql://localhost/test
 JWT_SECRET=e2e-jwt-secret-min-32-chars-for-tests
 OPEN_ROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxx
 
+# Optional: Override default AI model (default: meta-llama/llama-3.3-70b-instruct:free)
+# AI_DEFAULT_MODEL=meta-llama/llama-3.3-70b-instruct:free
+
 # Optional: GitHub OAuth (for OAuth route tests)
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=

--- a/apps/fastify/.env.test.example
+++ b/apps/fastify/.env.test.example
@@ -5,8 +5,8 @@ DATABASE_URL=postgresql://localhost/test
 JWT_SECRET=e2e-jwt-secret-min-32-chars-for-tests
 OPEN_ROUTER_API_KEY=sk-or-v1-xxxxxxxxxxxxxxxxxx
 
-# Optional: Override default AI model (default: meta-llama/llama-3.3-70b-instruct:free)
-# AI_DEFAULT_MODEL=meta-llama/llama-3.3-70b-instruct:free
+# Optional: Override default AI model (default: openrouter/free)
+# AI_DEFAULT_MODEL=openrouter/free
 
 # Optional: GitHub OAuth (for OAuth route tests)
 # GITHUB_CLIENT_ID=

--- a/apps/fastify/openapi/openapi.json
+++ b/apps/fastify/openapi/openapi.json
@@ -776,7 +776,7 @@
         "tags": [
           "ai"
         ],
-        "description": "Chat with AI via Open Router. Default model is configurable via AI_DEFAULT_MODEL (fallback: Llama 3.3 70B). Supports streaming and tools.",
+        "description": "Chat with AI via Open Router. Default model is configurable via AI_DEFAULT_MODEL (fallback: openrouter/free). Supports streaming and tools.",
         "requestBody": {
           "required": true,
           "content": {
@@ -834,7 +834,7 @@
                     "type": "boolean"
                   },
                   "model": {
-                    "default": "meta-llama/llama-3.3-70b-instruct:free",
+                    "default": "openrouter/free",
                     "type": "string"
                   },
                   "temperature": {

--- a/apps/fastify/openapi/openapi.json
+++ b/apps/fastify/openapi/openapi.json
@@ -776,7 +776,7 @@
         "tags": [
           "ai"
         ],
-        "description": "Chat with AI via Open Router. Default model: Llama 3.3 70B. Supports streaming and tools.",
+        "description": "Chat with AI via Open Router. Default model is configurable via AI_DEFAULT_MODEL (fallback: Llama 3.3 70B). Supports streaming and tools.",
         "requestBody": {
           "required": true,
           "content": {

--- a/apps/fastify/openapi/openapi.json
+++ b/apps/fastify/openapi/openapi.json
@@ -776,7 +776,7 @@
         "tags": [
           "ai"
         ],
-        "description": "Chat with AI via Open Router. Default model: Aurora Alpha. Supports streaming and tools.",
+        "description": "Chat with AI via Open Router. Default model: Llama 3.3 70B. Supports streaming and tools.",
         "requestBody": {
           "required": true,
           "content": {
@@ -834,7 +834,7 @@
                     "type": "boolean"
                   },
                   "model": {
-                    "default": "openrouter/aurora-alpha",
+                    "default": "meta-llama/llama-3.3-70b-instruct:free",
                     "type": "string"
                   },
                   "temperature": {

--- a/apps/fastify/src/lib/env.ts
+++ b/apps/fastify/src/lib/env.ts
@@ -55,6 +55,7 @@ export const env = createEnv({
     SENTRY_DSN: z.string().min(1).optional(),
     SENTRY_ENVIRONMENT: z.string().min(1).optional(),
     OPEN_ROUTER_API_KEY: z.string().min(1),
+    AI_DEFAULT_MODEL: z.string().min(1).optional(),
     ENCRYPTION_KEY: encryptionKeySchema,
     JWT_SECRET: jwtSecretSchema,
     ACCESS_JWT_EXPIRES_IN_SECONDS: z.coerce.number().int().positive().default(900),

--- a/apps/fastify/src/routes/ai/chat.test.ts
+++ b/apps/fastify/src/routes/ai/chat.test.ts
@@ -75,7 +75,7 @@ describe('POST /ai/chat', () => {
     expect(() => ChatResponseSchema.parse(data)).not.toThrow()
     expect(data.text).toBeTypeOf('string')
     expect(data.text.length).toBeGreaterThan(0)
-  }, 60000)
+  }, 120000)
 
   it('should return 200 when authenticated via API key', async () => {
     const apiKey = await getApiKeyToken(fastify, 'ai-chat-apikey@test.ai')

--- a/apps/fastify/src/routes/ai/chat.test.ts
+++ b/apps/fastify/src/routes/ai/chat.test.ts
@@ -58,7 +58,7 @@ describe('POST /ai/chat', () => {
     }
   })
 
-  it('should return 200 with default model (Aurora Alpha via Open Router)', async () => {
+  it('should return 200 with default model via Open Router', async () => {
     const response = await fastify.inject({
       method: 'POST',
       url: '/ai/chat',

--- a/apps/fastify/src/routes/ai/chat.ts
+++ b/apps/fastify/src/routes/ai/chat.ts
@@ -30,7 +30,7 @@ const ChatMessageItemSchema = Type.Union([
   }),
 ])
 /** Fixed default for OpenAPI/schema; runtime override via AI_DEFAULT_MODEL env. */
-const DEFAULT_AI_MODEL = 'meta-llama/llama-3.3-70b-instruct:free'
+const DEFAULT_AI_MODEL = 'openrouter/free'
 
 const ChatRequestSchema = Type.Object({
   messages: Type.Array(ChatMessageItemSchema, { minItems: 1, maxItems: 50 }),
@@ -167,7 +167,7 @@ const chatRoute: FastifyPluginAsync = async fastify => {
       schema: {
         operationId: 'chat',
         description:
-          'Chat with AI via Open Router. Default model is configurable via AI_DEFAULT_MODEL (fallback: Llama 3.3 70B). Supports streaming and tools.',
+          'Chat with AI via Open Router. Default model is configurable via AI_DEFAULT_MODEL (fallback: openrouter/free). Supports streaming and tools.',
         summary: 'Generate AI chat response',
         tags: ['ai'],
         security: [{ bearerAuth: [] }],

--- a/apps/fastify/src/routes/ai/chat.ts
+++ b/apps/fastify/src/routes/ai/chat.ts
@@ -32,7 +32,9 @@ const ChatMessageItemSchema = Type.Union([
 const ChatRequestSchema = Type.Object({
   messages: Type.Array(ChatMessageItemSchema, { minItems: 1, maxItems: 50 }),
   stream: Type.Optional(Type.Boolean()),
-  model: Type.Optional(Type.String({ default: 'openrouter/aurora-alpha' })),
+  model: Type.Optional(
+    Type.String({ default: env.AI_DEFAULT_MODEL ?? 'meta-llama/llama-3.3-70b-instruct:free' }),
+  ),
   temperature: Type.Optional(Type.Number({ minimum: 0, maximum: 2 })),
   tools: Type.Optional(Type.Any()),
 })
@@ -41,7 +43,7 @@ const ChatResponseSchema = Type.Object({
   text: Type.String(),
 })
 
-const DEFAULT_MODEL = 'openrouter/aurora-alpha'
+const DEFAULT_MODEL = env.AI_DEFAULT_MODEL ?? 'meta-llama/llama-3.3-70b-instruct:free'
 
 const MODEL_ALIASES: Record<string, string> = {
   'aurora-alpha': DEFAULT_MODEL,
@@ -163,7 +165,7 @@ const chatRoute: FastifyPluginAsync = async fastify => {
       schema: {
         operationId: 'chat',
         description:
-          'Chat with AI via Open Router. Default model: Aurora Alpha. Supports streaming and tools.',
+          'Chat with AI via Open Router. Default model: Llama 3.3 70B. Supports streaming and tools.',
         summary: 'Generate AI chat response',
         tags: ['ai'],
         security: [{ bearerAuth: [] }],

--- a/apps/fastify/src/routes/ai/chat.ts
+++ b/apps/fastify/src/routes/ai/chat.ts
@@ -29,12 +29,13 @@ const ChatMessageItemSchema = Type.Union([
     parts: Type.Array(Type.Any()),
   }),
 ])
+/** Fixed default for OpenAPI/schema; runtime override via AI_DEFAULT_MODEL env. */
+const DEFAULT_AI_MODEL = 'meta-llama/llama-3.3-70b-instruct:free'
+
 const ChatRequestSchema = Type.Object({
   messages: Type.Array(ChatMessageItemSchema, { minItems: 1, maxItems: 50 }),
   stream: Type.Optional(Type.Boolean()),
-  model: Type.Optional(
-    Type.String({ default: env.AI_DEFAULT_MODEL ?? 'meta-llama/llama-3.3-70b-instruct:free' }),
-  ),
+  model: Type.Optional(Type.String({ default: DEFAULT_AI_MODEL })),
   temperature: Type.Optional(Type.Number({ minimum: 0, maximum: 2 })),
   tools: Type.Optional(Type.Any()),
 })
@@ -43,10 +44,8 @@ const ChatResponseSchema = Type.Object({
   text: Type.String(),
 })
 
-const DEFAULT_MODEL = env.AI_DEFAULT_MODEL ?? 'meta-llama/llama-3.3-70b-instruct:free'
-
 const MODEL_ALIASES: Record<string, string> = {
-  'aurora-alpha': DEFAULT_MODEL,
+  'aurora-alpha': DEFAULT_AI_MODEL,
   grok: 'x-ai/grok-3-mini',
   'grok-3-mini': 'x-ai/grok-3-mini',
   sonnet: 'anthropic/claude-3-5-sonnet',
@@ -58,7 +57,10 @@ function getOpenRouter() {
 }
 
 function resolveModel(model?: string) {
-  const m = model ?? DEFAULT_MODEL
+  const defaultModel = env.AI_DEFAULT_MODEL ?? DEFAULT_AI_MODEL
+  const useRuntimeDefault =
+    model === undefined || model === DEFAULT_AI_MODEL || model === 'aurora-alpha'
+  const m = useRuntimeDefault ? defaultModel : model
   const modelId = MODEL_ALIASES[m] ?? (m.startsWith('gpt') ? `openai/${m}` : m)
   return getOpenRouter().chat(modelId)
 }
@@ -165,7 +167,7 @@ const chatRoute: FastifyPluginAsync = async fastify => {
       schema: {
         operationId: 'chat',
         description:
-          'Chat with AI via Open Router. Default model: Llama 3.3 70B. Supports streaming and tools.',
+          'Chat with AI via Open Router. Default model is configurable via AI_DEFAULT_MODEL (fallback: Llama 3.3 70B). Supports streaming and tools.',
         summary: 'Generate AI chat response',
         tags: ['ai'],
         security: [{ bearerAuth: [] }],

--- a/packages/core/src/gen/sdk.gen.ts
+++ b/packages/core/src/gen/sdk.gen.ts
@@ -121,7 +121,7 @@ export const accountLinkWalletVerify = <ThrowOnError extends boolean = false>(op
 /**
  * Generate AI chat response
  *
- * Chat with AI via Open Router. Default model: Aurora Alpha. Supports streaming and tools.
+ * Chat with AI via Open Router. Default model is configurable via AI_DEFAULT_MODEL (fallback: Llama 3.3 70B). Supports streaming and tools.
  */
 export const chat = <ThrowOnError extends boolean = false>(options: Options<ChatData, ThrowOnError>) => (options.client ?? client).post<ChatResponses, ChatErrors, ThrowOnError>({
     security: [{ scheme: 'bearer', type: 'http' }],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Added AI_DEFAULT_MODEL environment variable; runtime fallback set to openrouter/free.

* **Documentation**
  * API docs and endpoint descriptions updated to reflect the configurable default model and new fallback.

* **Chores**
  * CI workflow environment updated to include the new model configuration.

* **Tests**
  * Chat endpoint test description updated and timeout increased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->