### PR TITLE
feat(assistant): update chat functionality

### DIFF
--- a/.cursor/rules/frontend/e2e-playwright.mdc
+++ b/.cursor/rules/frontend/e2e-playwright.mdc
@@ -22,6 +22,9 @@ glob: "apps/next/e2e/**/*, apps/next/playwright.config.ts, apps/fastify/test/**/
 - Chromium project: chat-assistant (uses authenticatedPage; fixture triggers magic link login)
 - Security project: authenticator, passkeys, api-keys (use authenticatedPage; TOTP spec uses extractSessionToken for test endpoint)
 
+## Disabled Specs
+- chat-assistant skipped until OLLAMA_BASE_URL or valid OPEN_ROUTER_API_KEY secret in CI
+
 ## Auth Fixtures
 - Login/logout tests: import `@playwright/test`, use `page` (fresh context per test)
 - Authed feature tests: import from `e2e/fixtures`, use `authenticatedPage`; no `loginAsTestUser` in test body

--- a/.cursor/rules/frontend/e2e-playwright.mdc
+++ b/.cursor/rules/frontend/e2e-playwright.mdc
@@ -22,9 +22,6 @@ glob: "apps/next/e2e/**/*, apps/next/playwright.config.ts, apps/fastify/test/**/
 - Chromium project: chat-assistant (uses authenticatedPage; fixture triggers magic link login)
 - Security project: authenticator, passkeys, api-keys (use authenticatedPage; TOTP spec uses extractSessionToken for test endpoint)
 
-## Disabled Specs
-- chat-assistant skipped (test.describe.skip) until getAuthToken fixed for chat transport
-
 ## Auth Fixtures
 - Login/logout tests: import `@playwright/test`, use `page` (fresh context per test)
 - Authed feature tests: import from `e2e/fixtures`, use `authenticatedPage`; no `loginAsTestUser` in test body

--- a/.cursor/rules/frontend/e2e-playwright.mdc
+++ b/.cursor/rules/frontend/e2e-playwright.mdc
@@ -22,9 +22,6 @@ glob: "apps/next/e2e/**/*, apps/next/playwright.config.ts, apps/fastify/test/**/
 - Chromium project: chat-assistant (uses authenticatedPage; fixture triggers magic link login)
 - Security project: authenticator, passkeys, api-keys (use authenticatedPage; TOTP spec uses extractSessionToken for test endpoint)
 
-## Disabled Specs
-- chat-assistant skipped until OLLAMA_BASE_URL or valid OPEN_ROUTER_API_KEY secret in CI
-
 ## Auth Fixtures
 - Login/logout tests: import `@playwright/test`, use `page` (fresh context per test)
 - Authed feature tests: import from `e2e/fixtures`, use `authenticatedPage`; no `loginAsTestUser` in test body

--- a/.github/workflows/next-e2e.yml
+++ b/.github/workflows/next-e2e.yml
@@ -28,7 +28,6 @@ env:
   JWT_SECRET: e2e-jwt-secret-min-32-chars-for-tests
   NEXT_PUBLIC_API_URL: http://localhost:3001
   OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
-  OPEN_ROUTER_API_KEY: ${{ secrets.OPEN_ROUTER_API_KEY != '' && secrets.OPEN_ROUTER_API_KEY || 'sk-or-v1-dummy-key-for-unit-tests' }}
 
 jobs:
   build-and-test:

--- a/apps/docu/content/docs/deployment/self-hosted-llm.mdx
+++ b/apps/docu/content/docs/deployment/self-hosted-llm.mdx
@@ -257,7 +257,11 @@ The Fastify chat route (`/ai/chat`) uses **Ollama as the default** AI provider w
 
 ### Tool Support Caveat
 
-Small Ollama models (e.g. `qwen2.5:3b`) may not reliably support tool/function-calling. For better tool use (e.g. `getAccountInfo`), use 7B+ models such as `llama3.1:8b` or `mistral:7b`.
+Small Ollama models (e.g. `qwen2.5:3b`) may not reliably support tool/function-calling. For better tool use (e.g. `getAccountInfo`, `braveSearch`), use 7B+ models such as `llama3.1:8b` or `mistral:7b`.
+
+### Optional: Brave Search (Web Search Tool)
+
+Set `BRAVE_SEARCH_API_KEY` to enable the web search tool. The assistant can then search the web when users ask for current or recent information. Free tier: 2,000 queries/month. See [Brave Search API](https://api.search.brave.com/).
 
 ---
 

--- a/apps/docu/content/docs/testing/e2e-testing.mdx
+++ b/apps/docu/content/docs/testing/e2e-testing.mdx
@@ -78,7 +78,7 @@ See [Vercel Protection Bypass for Automation](https://vercel.com/docs/security/d
 
 ## Environment Variables
 
-- **Chat E2E** (chat-assistant.spec.ts): Requires a real AI provider. Use `OLLAMA_BASE_URL` (e.g. `http://localhost:11434`) or valid `OPEN_ROUTER_API_KEY`. Local: add to `apps/fastify/.env.test`. CI: add `OLLAMA_BASE_URL` or `OPEN_ROUTER_API_KEY` to GitHub secrets to enable (otherwise skipped; workflow uses dummy key when secret unset). Uses `authenticatedPage` fixture.
+- **Chat E2E** (chat-assistant.spec.ts): Uses Ollama only (`OLLAMA_BASE_URL` secret). CI and `test:e2e:local` force `AI_PROVIDER=ollama` and omit OpenRouter. Uses `authenticatedPage` fixture.
 - **E2E CI**: Uses local servers only; no Vercel URLs. For manual testing against previews, pass `--app`/`--api` URLs.
 
 ## ALLOW_TEST
@@ -94,7 +94,7 @@ See [Vercel Protection Bypass for Automation](https://vercel.com/docs/security/d
 | Spec | Coverage |
 |------|----------|
 | `magic-link-auth.spec.ts` | Magic link login, invalid/expired token errors, email validation, protected route, JWT session |
-| `chat-assistant.spec.ts` | Chat UI with authenticatedPage; Who am I? prompt (skipped until AI provider secret in CI) |
+| `chat-assistant.spec.ts` | Chat UI with authenticatedPage; Who am I? prompt |
 | `security/api-keys.spec.ts` | API keys CRUD: create, revoke, empty state |
 | `security/authenticator.spec.ts` | TOTP setup/unlink via extractSessionToken + test endpoint |
 | `security/passkeys.spec.ts` | Passkeys add/remove with CDP virtual authenticator |

--- a/apps/docu/content/docs/testing/e2e-testing.mdx
+++ b/apps/docu/content/docs/testing/e2e-testing.mdx
@@ -78,7 +78,7 @@ See [Vercel Protection Bypass for Automation](https://vercel.com/docs/security/d
 
 ## Environment Variables
 
-- **Chat E2E** (chat-assistant.spec.ts): Requires an AI provider. Use `OLLAMA_BASE_URL` (e.g. `http://localhost:11434` for local Ollama) or `OPEN_ROUTER_API_KEY`. Local: add to `apps/fastify/.env.test`. CI: uses `OLLAMA_BASE_URL` or `OPEN_ROUTER_API_KEY` from workflow env. Uses `authenticatedPage` fixture for auth.
+- **Chat E2E** (chat-assistant.spec.ts): Requires a real AI provider. Use `OLLAMA_BASE_URL` (e.g. `http://localhost:11434`) or valid `OPEN_ROUTER_API_KEY`. Local: add to `apps/fastify/.env.test`. CI: add `OLLAMA_BASE_URL` or `OPEN_ROUTER_API_KEY` to GitHub secrets to enable (otherwise skipped; workflow uses dummy key when secret unset). Uses `authenticatedPage` fixture.
 - **E2E CI**: Uses local servers only; no Vercel URLs. For manual testing against previews, pass `--app`/`--api` URLs.
 
 ## ALLOW_TEST
@@ -94,7 +94,7 @@ See [Vercel Protection Bypass for Automation](https://vercel.com/docs/security/d
 | Spec | Coverage |
 |------|----------|
 | `magic-link-auth.spec.ts` | Magic link login, invalid/expired token errors, email validation, protected route, JWT session |
-| `chat-assistant.spec.ts` | Chat UI with authenticatedPage; Who am I? prompt |
+| `chat-assistant.spec.ts` | Chat UI with authenticatedPage; Who am I? prompt (skipped until AI provider secret in CI) |
 | `security/api-keys.spec.ts` | API keys CRUD: create, revoke, empty state |
 | `security/authenticator.spec.ts` | TOTP setup/unlink via extractSessionToken + test endpoint |
 | `security/passkeys.spec.ts` | Passkeys add/remove with CDP virtual authenticator |

--- a/apps/docu/content/docs/testing/e2e-testing.mdx
+++ b/apps/docu/content/docs/testing/e2e-testing.mdx
@@ -78,7 +78,7 @@ See [Vercel Protection Bypass for Automation](https://vercel.com/docs/security/d
 
 ## Environment Variables
 
-- **Chat E2E** (chat-assistant.spec.ts): Requires an AI provider. Use `OLLAMA_BASE_URL` (e.g. `http://localhost:11434` for local Ollama) or `OPEN_ROUTER_API_KEY`. Local: add to `apps/fastify/.env.test`. CI: uses `OLLAMA_BASE_URL` or `OPEN_ROUTER_API_KEY` from workflow env. Currently skipped: `getAuthToken` returns null for the chat transport in E2E.
+- **Chat E2E** (chat-assistant.spec.ts): Requires an AI provider. Use `OLLAMA_BASE_URL` (e.g. `http://localhost:11434` for local Ollama) or `OPEN_ROUTER_API_KEY`. Local: add to `apps/fastify/.env.test`. CI: uses `OLLAMA_BASE_URL` or `OPEN_ROUTER_API_KEY` from workflow env. Uses `authenticatedPage` fixture for auth.
 - **E2E CI**: Uses local servers only; no Vercel URLs. For manual testing against previews, pass `--app`/`--api` URLs.
 
 ## ALLOW_TEST
@@ -94,7 +94,7 @@ See [Vercel Protection Bypass for Automation](https://vercel.com/docs/security/d
 | Spec | Coverage |
 |------|----------|
 | `magic-link-auth.spec.ts` | Magic link login, invalid/expired token errors, email validation, protected route, JWT session |
-| `chat-assistant.spec.ts` | Chat UI with authenticatedPage; Who am I? prompt (skipped until getAuthToken fixed) |
+| `chat-assistant.spec.ts` | Chat UI with authenticatedPage; Who am I? prompt |
 | `security/api-keys.spec.ts` | API keys CRUD: create, revoke, empty state |
 | `security/authenticator.spec.ts` | TOTP setup/unlink via extractSessionToken + test endpoint |
 | `security/passkeys.spec.ts` | Passkeys add/remove with CDP virtual authenticator |
@@ -119,10 +119,6 @@ flowchart TB
 
   MagicLinkAuth --> ChromiumProj --> SecurityProj
 ```
-
-### Disabled / skipped specs
-
-chat-assistant skipped (test.describe.skip) until getAuthToken fixed for chat transport.
 
 ## Troubleshooting
 

--- a/apps/fastify/.env-sample
+++ b/apps/fastify/.env-sample
@@ -11,6 +11,9 @@ OLLAMA_BASE_URL=https://ollama.example.com
 # Optional: Override default model. Ollama: qwen2.5:3b. Open Router: openrouter/free
 # AI_DEFAULT_MODEL=qwen2.5:3b
 
+# Optional: Brave Search API (enables web search tool in chat)
+# BRAVE_SEARCH_API_KEY=BSA...
+
 # JWT signing secret. Must match Next.js. Min 32 chars.
 JWT_SECRET=default-jwt-secret-min-32-chars-for-dev
 

--- a/apps/fastify/src/lib/env.ts
+++ b/apps/fastify/src/lib/env.ts
@@ -58,6 +58,7 @@ export const env = createEnv({
     AI_PROVIDER: z.enum(['ollama', 'openrouter']).optional(),
     OPEN_ROUTER_API_KEY: z.string().min(1).optional(),
     AI_DEFAULT_MODEL: z.string().min(1).optional(),
+    BRAVE_SEARCH_API_KEY: z.string().min(1).optional(),
     ENCRYPTION_KEY: encryptionKeySchema,
     JWT_SECRET: jwtSecretSchema,
     ACCESS_JWT_EXPIRES_IN_SECONDS: z.coerce.number().int().positive().default(900),

--- a/apps/fastify/src/routes/ai/brave-search.ts
+++ b/apps/fastify/src/routes/ai/brave-search.ts
@@ -1,0 +1,52 @@
+import { captureError } from '@repo/error/node'
+import { tool } from 'ai'
+import type { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+
+const maxBraveResults = 8
+
+export function createBraveSearchTool(apiKey: string, log: FastifyBaseLogger) {
+  return tool({
+    description:
+      'Search the web for current information. Use when the user asks about recent events, news, facts, or anything that requires up-to-date web results.',
+    inputSchema: z.object({ query: z.string().min(1) }),
+    execute: async ({ query }: { query: string }) => {
+      try {
+        const url = `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}`
+        const res = await fetch(url, {
+          headers: { 'X-Subscription-Token': apiKey },
+        })
+        if (res.status === 401 || res.status === 403)
+          return 'Brave Search API key invalid or missing.'
+        if (res.status === 429) return 'Brave Search rate limit reached. Try again later.'
+        if (!res.ok) {
+          captureError({
+            error: new Error(`Brave Search API error: ${res.status} ${res.statusText}`),
+            label: 'Brave Search',
+            logger: log,
+          })
+          return 'Search failed. Please try again.'
+        }
+        const data = (await res.json()) as {
+          web?: { results?: Array<{ title?: string; url?: string; description?: string }> }
+        }
+        const results = data?.web?.results ?? []
+        if (results.length === 0) return 'No results found for this query.'
+        const lines = results.slice(0, maxBraveResults).map((r, i) => {
+          const title = r.title ?? 'Untitled'
+          const urlStr = r.url ?? ''
+          const desc = r.description ?? ''
+          return `${i + 1}. ${title} (${urlStr})\n   ${desc}`
+        })
+        return lines.join('\n\n')
+      } catch (err) {
+        captureError({
+          error: err instanceof Error ? err : new Error(String(err)),
+          label: 'Brave Search',
+          logger: log,
+        })
+        return 'Search failed. Please try again.'
+      }
+    },
+  })
+}

--- a/apps/fastify/src/routes/ai/chat.ts
+++ b/apps/fastify/src/routes/ai/chat.ts
@@ -19,6 +19,7 @@ import { getDb } from '../../db/index.js'
 import { users } from '../../db/schema/index.js'
 import { env } from '../../lib/env.js'
 import { ErrorResponseSchema } from '../schemas.js'
+import { createBraveSearchTool } from './brave-search.js'
 
 const ChatMessageItemSchema = Type.Union([
   Type.Object({
@@ -237,6 +238,9 @@ const chatRoute: FastifyPluginAsync = async fastify => {
 
       const mergedTools: ToolSet = {
         getAccountInfo: createAccountInfoTool(request.session.user.id),
+        ...(env.BRAVE_SEARCH_API_KEY && {
+          braveSearch: createBraveSearchTool(env.BRAVE_SEARCH_API_KEY, request.log),
+        }),
       }
 
       let messages: Awaited<ReturnType<typeof resolveMessages>>

--- a/apps/fastify/src/routes/ai/chat.ts
+++ b/apps/fastify/src/routes/ai/chat.ts
@@ -143,6 +143,7 @@ function buildUserInfoSpec(user: {
   name: string | null
   email: string | null
   image: string | null
+  username: string | null
   createdAt: Date
 }) {
   const joinedAt = new Intl.DateTimeFormat('en-US', {
@@ -159,6 +160,7 @@ function buildUserInfoSpec(user: {
           name: user.name ?? null,
           email: user.email ?? null,
           image: user.image ?? null,
+          username: user.username ?? null,
           joinedAt,
         },
         children: [],
@@ -180,6 +182,7 @@ function createAccountInfoTool(userId: string) {
       const summaryParts = [`You joined in ${spec.elements[userInfoSpecRoot].props.joinedAt}`]
       if (user.email) summaryParts.push(`Email: ${user.email}`)
       if (user.name) summaryParts.push(`Name: ${user.name}`)
+      if (user.username) summaryParts.push(`Username: ${user.username}`)
       return {
         __render: 'user-info',
         spec,

--- a/apps/next/components/assistant/assistant-chat.tsx
+++ b/apps/next/components/assistant/assistant-chat.tsx
@@ -15,7 +15,7 @@ import { userInfoRegistry } from 'components/assistant/user-info-catalog'
 import { MessageCircleIcon } from 'lucide-react'
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from 'react'
 
-const suggestions = ['Who am I?', 'What can you help with?', 'Tell me a joke']
+const suggestions = ['Who am I?', 'What can you help with?']
 
 function isUserInfoSpecOutput(
   output: unknown,

--- a/apps/next/components/assistant/user-info-catalog.tsx
+++ b/apps/next/components/assistant/user-info-catalog.tsx
@@ -15,8 +15,9 @@ export const userInfoCatalog = defineCatalog(schema, {
         email: z.string().nullable(),
         joinedAt: z.string(),
         image: z.string().nullable(),
+        username: z.string().nullable(),
       }),
-      description: 'Account info card with avatar, name, email, joined date',
+      description: 'Account info card with avatar, name, email, username, joined date',
     },
   },
   actions: {},
@@ -37,7 +38,13 @@ function getInitials(name: string | null, email: string | null): string {
 function UserInfoComponent({
   props,
 }: {
-  props: { name: string | null; email: string | null; joinedAt: string; image: string | null }
+  props: {
+    name: string | null
+    email: string | null
+    joinedAt: string
+    image: string | null
+    username: string | null
+  }
 }) {
   return (
     <Card
@@ -56,6 +63,9 @@ function UserInfoComponent({
       </Avatar>
       <div className="min-w-0 flex-1 space-y-0.5">
         {props.name ? <p className="font-medium truncate">{props.name}</p> : null}
+        {props.username ? (
+          <p className="text-muted-foreground text-sm truncate">@{props.username}</p>
+        ) : null}
         {props.email ? (
           <p className="text-muted-foreground text-sm truncate">{props.email}</p>
         ) : null}

--- a/apps/next/e2e/chat-assistant.spec.ts
+++ b/apps/next/e2e/chat-assistant.spec.ts
@@ -1,39 +1,42 @@
 import { expect, test } from './fixtures'
 
-test.describe('Chat Assistant', () => {
-  test.use({ viewport: { width: 375, height: 667 } })
+test.describe
+  .skip('Chat Assistant', () => {
+    test.use({ viewport: { width: 375, height: 667 } })
 
-  test('should send message via Who am I? and show assistant response', async ({
-    authenticatedPage: page,
-  }) => {
-    test.setTimeout(120000)
-    await page.goto('/')
-    await expect(page.locator('text=Signed In')).toBeVisible({ timeout: 15000 })
-    await expect(page.locator('text=API OK')).toBeVisible({ timeout: 15000 })
+    test('should send message via Who am I? and show assistant response', async ({
+      authenticatedPage: page,
+    }) => {
+      test.setTimeout(120000)
+      await page.goto('/')
+      await expect(page.locator('text=Signed In')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('text=API OK')).toBeVisible({ timeout: 15000 })
 
-    await page.getByRole('button', { name: 'Open assistant' }).click()
-    const sheet = page.getByRole('dialog')
-    await expect(sheet).toBeVisible({ timeout: 5000 })
-    await expect(sheet.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 5000 })
-    await sheet.getByRole('button', { name: 'Who am I?' }).click()
+      await page.getByRole('button', { name: 'Open assistant' }).click()
+      const sheet = page.getByRole('dialog')
+      await expect(sheet).toBeVisible({ timeout: 5000 })
+      await expect(sheet.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 5000 })
+      await sheet.getByRole('button', { name: 'Who am I?' }).click()
 
-    await expect(sheet.locator('[data-role="user"]').filter({ hasText: 'Who am I?' })).toBeVisible({
-      timeout: 10000,
-    })
+      await expect(
+        sheet.locator('[data-role="user"]').filter({ hasText: 'Who am I?' }),
+      ).toBeVisible({
+        timeout: 10000,
+      })
 
-    const chatError = sheet.getByTestId('chat-error')
-    const errorVisible = await chatError.isVisible().catch(() => false)
-    if (errorVisible) {
-      const errorText = (await chatError.textContent()) ?? ''
-      if (/402|insufficient|credits/i.test(errorText)) {
-        process.stderr.write(
-          '[E2E Chat] OpenRouter 402 insufficient credits - passing without validation\n',
-        )
-        return
+      const chatError = sheet.getByTestId('chat-error')
+      const errorVisible = await chatError.isVisible().catch(() => false)
+      if (errorVisible) {
+        const errorText = (await chatError.textContent()) ?? ''
+        if (/402|insufficient|credits/i.test(errorText)) {
+          process.stderr.write(
+            '[E2E Chat] OpenRouter 402 insufficient credits - passing without validation\n',
+          )
+          return
+        }
       }
-    }
-    await expect(chatError).not.toBeVisible()
-    await expect(sheet.locator('[data-role="assistant"]')).toBeVisible({ timeout: 60000 })
-    await expect(sheet.getByTestId('user-info-card')).toBeVisible({ timeout: 60000 })
+      await expect(chatError).not.toBeVisible()
+      await expect(sheet.locator('[data-role="assistant"]')).toBeVisible({ timeout: 60000 })
+      await expect(sheet.getByTestId('user-info-card')).toBeVisible({ timeout: 60000 })
+    })
   })
-})

--- a/apps/next/e2e/chat-assistant.spec.ts
+++ b/apps/next/e2e/chat-assistant.spec.ts
@@ -1,43 +1,39 @@
 import { expect, test } from './fixtures'
 
-// Skip: requires real AI provider (OLLAMA_BASE_URL or valid OPEN_ROUTER_API_KEY). CI uses dummy key when secret unset.
-test.describe
-  .skip('Chat Assistant', () => {
-    test.use({ viewport: { width: 375, height: 667 } })
+test.describe('Chat Assistant', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
 
-    test('should send message via Who am I? and show assistant response', async ({
-      authenticatedPage: page,
-    }) => {
-      test.setTimeout(120000)
-      await page.goto('/')
-      await expect(page.locator('text=Signed In')).toBeVisible({ timeout: 15000 })
-      await expect(page.locator('text=API OK')).toBeVisible({ timeout: 15000 })
+  test('should send message via Who am I? and show assistant response', async ({
+    authenticatedPage: page,
+  }) => {
+    test.setTimeout(120000)
+    await page.goto('/')
+    await expect(page.locator('text=Signed In')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('text=API OK')).toBeVisible({ timeout: 15000 })
 
-      await page.getByRole('button', { name: 'Open assistant' }).click()
-      const sheet = page.getByRole('dialog')
-      await expect(sheet).toBeVisible({ timeout: 5000 })
-      await expect(sheet.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 5000 })
-      await sheet.getByRole('button', { name: 'Who am I?' }).click()
+    await page.getByRole('button', { name: 'Open assistant' }).click()
+    const sheet = page.getByRole('dialog')
+    await expect(sheet).toBeVisible({ timeout: 5000 })
+    await expect(sheet.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 5000 })
+    await sheet.getByRole('button', { name: 'Who am I?' }).click()
 
-      await expect(
-        sheet.locator('[data-role="user"]').filter({ hasText: 'Who am I?' }),
-      ).toBeVisible({
-        timeout: 10000,
-      })
-
-      const chatError = sheet.getByTestId('chat-error')
-      const errorVisible = await chatError.isVisible().catch(() => false)
-      if (errorVisible) {
-        const errorText = (await chatError.textContent()) ?? ''
-        if (/402|insufficient|credits/i.test(errorText)) {
-          process.stderr.write(
-            '[E2E Chat] OpenRouter 402 insufficient credits - passing without validation\n',
-          )
-          return
-        }
-      }
-      await expect(chatError).not.toBeVisible()
-      await expect(sheet.locator('[data-role="assistant"]')).toBeVisible({ timeout: 60000 })
-      await expect(sheet.getByTestId('user-info-card')).toBeVisible({ timeout: 60000 })
+    await expect(sheet.locator('[data-role="user"]').filter({ hasText: 'Who am I?' })).toBeVisible({
+      timeout: 10000,
     })
+
+    const chatError = sheet.getByTestId('chat-error')
+    const errorVisible = await chatError.isVisible().catch(() => false)
+    if (errorVisible) {
+      const errorText = (await chatError.textContent()) ?? ''
+      if (/402|insufficient|credits/i.test(errorText)) {
+        process.stderr.write(
+          '[E2E Chat] OpenRouter 402 insufficient credits - passing without validation\n',
+        )
+        return
+      }
+    }
+    await expect(chatError).not.toBeVisible()
+    await expect(sheet.locator('[data-role="assistant"]')).toBeVisible({ timeout: 60000 })
+    await expect(sheet.getByTestId('user-info-card')).toBeVisible({ timeout: 60000 })
   })
+})

--- a/apps/next/e2e/chat-assistant.spec.ts
+++ b/apps/next/e2e/chat-assistant.spec.ts
@@ -1,40 +1,39 @@
-import { expect, test } from '@playwright/test'
-import { authHelpers } from './auth-helpers'
+import { expect, test } from './fixtures'
 
-// Skip: getAuthToken returns null for chat transport despite Signed In (useUser works; chat gets UNAUTHORIZED)
-test.describe
-  .skip('Chat Assistant', () => {
-    test.use({ viewport: { width: 375, height: 667 } })
+test.describe('Chat Assistant', () => {
+  test.use({ viewport: { width: 375, height: 667 } })
 
-    test('should send message via Who am I? and show assistant response', async ({ page }) => {
-      test.setTimeout(120000)
-      await authHelpers.loginAsTestUser(page)
-      await expect(page.locator('text=Signed In')).toBeVisible({ timeout: 15000 })
-      await expect(page.locator('text=API OK')).toBeVisible({ timeout: 15000 })
+  test('should send message via Who am I? and show assistant response', async ({
+    authenticatedPage: page,
+  }) => {
+    test.setTimeout(120000)
+    await page.goto('/')
+    await expect(page.locator('text=Signed In')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('text=API OK')).toBeVisible({ timeout: 15000 })
 
-      await page.getByRole('button', { name: 'Open assistant' }).click()
-      const sheet = page.getByRole('dialog')
-      await expect(sheet).toBeVisible({ timeout: 5000 })
-      await expect(sheet.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 5000 })
-      await sheet.getByRole('button', { name: 'Who am I?' }).click()
+    await page.getByRole('button', { name: 'Open assistant' }).click()
+    const sheet = page.getByRole('dialog')
+    await expect(sheet).toBeVisible({ timeout: 5000 })
+    await expect(sheet.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 5000 })
+    await sheet.getByRole('button', { name: 'Who am I?' }).click()
 
-      await expect(
-        sheet.locator('[data-role="user"]').filter({ hasText: 'Who am I?' }),
-      ).toBeVisible({ timeout: 10000 })
-
-      const chatError = sheet.getByTestId('chat-error')
-      const errorVisible = await chatError.isVisible().catch(() => false)
-      if (errorVisible) {
-        const errorText = (await chatError.textContent()) ?? ''
-        if (/402|insufficient|credits/i.test(errorText)) {
-          process.stderr.write(
-            '[E2E Chat] OpenRouter 402 insufficient credits - passing without validation\n',
-          )
-          return
-        }
-      }
-      await expect(chatError).not.toBeVisible()
-      await expect(sheet.locator('[data-role="assistant"]')).toBeVisible({ timeout: 60000 })
-      await expect(sheet.getByTestId('user-info-card')).toBeVisible({ timeout: 60000 })
+    await expect(sheet.locator('[data-role="user"]').filter({ hasText: 'Who am I?' })).toBeVisible({
+      timeout: 10000,
     })
+
+    const chatError = sheet.getByTestId('chat-error')
+    const errorVisible = await chatError.isVisible().catch(() => false)
+    if (errorVisible) {
+      const errorText = (await chatError.textContent()) ?? ''
+      if (/402|insufficient|credits/i.test(errorText)) {
+        process.stderr.write(
+          '[E2E Chat] OpenRouter 402 insufficient credits - passing without validation\n',
+        )
+        return
+      }
+    }
+    await expect(chatError).not.toBeVisible()
+    await expect(sheet.locator('[data-role="assistant"]')).toBeVisible({ timeout: 60000 })
+    await expect(sheet.getByTestId('user-info-card')).toBeVisible({ timeout: 60000 })
   })
+})

--- a/apps/next/e2e/chat-assistant.spec.ts
+++ b/apps/next/e2e/chat-assistant.spec.ts
@@ -1,39 +1,43 @@
 import { expect, test } from './fixtures'
 
-test.describe('Chat Assistant', () => {
-  test.use({ viewport: { width: 375, height: 667 } })
+// Skip: requires real AI provider (OLLAMA_BASE_URL or valid OPEN_ROUTER_API_KEY). CI uses dummy key when secret unset.
+test.describe
+  .skip('Chat Assistant', () => {
+    test.use({ viewport: { width: 375, height: 667 } })
 
-  test('should send message via Who am I? and show assistant response', async ({
-    authenticatedPage: page,
-  }) => {
-    test.setTimeout(120000)
-    await page.goto('/')
-    await expect(page.locator('text=Signed In')).toBeVisible({ timeout: 15000 })
-    await expect(page.locator('text=API OK')).toBeVisible({ timeout: 15000 })
+    test('should send message via Who am I? and show assistant response', async ({
+      authenticatedPage: page,
+    }) => {
+      test.setTimeout(120000)
+      await page.goto('/')
+      await expect(page.locator('text=Signed In')).toBeVisible({ timeout: 15000 })
+      await expect(page.locator('text=API OK')).toBeVisible({ timeout: 15000 })
 
-    await page.getByRole('button', { name: 'Open assistant' }).click()
-    const sheet = page.getByRole('dialog')
-    await expect(sheet).toBeVisible({ timeout: 5000 })
-    await expect(sheet.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 5000 })
-    await sheet.getByRole('button', { name: 'Who am I?' }).click()
+      await page.getByRole('button', { name: 'Open assistant' }).click()
+      const sheet = page.getByRole('dialog')
+      await expect(sheet).toBeVisible({ timeout: 5000 })
+      await expect(sheet.getByPlaceholder('Type a message...')).toBeVisible({ timeout: 5000 })
+      await sheet.getByRole('button', { name: 'Who am I?' }).click()
 
-    await expect(sheet.locator('[data-role="user"]').filter({ hasText: 'Who am I?' })).toBeVisible({
-      timeout: 10000,
-    })
+      await expect(
+        sheet.locator('[data-role="user"]').filter({ hasText: 'Who am I?' }),
+      ).toBeVisible({
+        timeout: 10000,
+      })
 
-    const chatError = sheet.getByTestId('chat-error')
-    const errorVisible = await chatError.isVisible().catch(() => false)
-    if (errorVisible) {
-      const errorText = (await chatError.textContent()) ?? ''
-      if (/402|insufficient|credits/i.test(errorText)) {
-        process.stderr.write(
-          '[E2E Chat] OpenRouter 402 insufficient credits - passing without validation\n',
-        )
-        return
+      const chatError = sheet.getByTestId('chat-error')
+      const errorVisible = await chatError.isVisible().catch(() => false)
+      if (errorVisible) {
+        const errorText = (await chatError.textContent()) ?? ''
+        if (/402|insufficient|credits/i.test(errorText)) {
+          process.stderr.write(
+            '[E2E Chat] OpenRouter 402 insufficient credits - passing without validation\n',
+          )
+          return
+        }
       }
-    }
-    await expect(chatError).not.toBeVisible()
-    await expect(sheet.locator('[data-role="assistant"]')).toBeVisible({ timeout: 60000 })
-    await expect(sheet.getByTestId('user-info-card')).toBeVisible({ timeout: 60000 })
+      await expect(chatError).not.toBeVisible()
+      await expect(sheet.locator('[data-role="assistant"]')).toBeVisible({ timeout: 60000 })
+      await expect(sheet.getByTestId('user-info-card')).toBeVisible({ timeout: 60000 })
+    })
   })
-})

--- a/apps/next/playwright.config.ts
+++ b/apps/next/playwright.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       name: 'chromium',
       testMatch: ['**/chat-assistant.spec.ts'],
       use: { ...devices['Desktop Chrome'] },
+      dependencies: ['auth'],
     },
     {
       name: 'security',

--- a/apps/next/scripts/run-e2e-local.mjs
+++ b/apps/next/scripts/run-e2e-local.mjs
@@ -88,9 +88,11 @@ async function main() {
     PGLITE: 'true',
     NODE_ENV: 'test',
     NEXT_PUBLIC_API_URL: 'http://localhost:3001',
+    AI_PROVIDER: 'ollama',
     JWT_SECRET:
       loaded.JWT_SECRET ?? process.env.JWT_SECRET ?? 'e2e-jwt-secret-min-32-chars-for-tests',
   }
+  delete env.OPEN_ROUTER_API_KEY
 
   const fastify = spawn('node', ['--import', 'tsx', 'server.ts'], {
     cwd: join(repoRoot, 'apps/fastify'),

--- a/scripts/run-qa.mjs
+++ b/scripts/run-qa.mjs
@@ -15,6 +15,8 @@ const qaBuildEnv = process.env.JWT_SECRET
   ? undefined
   : { JWT_SECRET: 'qa-build-placeholder-min-32-chars-to-pass-validation' }
 
+const skipTests = process.env.QA_SKIP_TESTS === '1' || process.env.QA_SKIP_TESTS === 'true'
+
 const phases = [
   { name: 'install', cmd: 'pnpm', args: ['i', '--no-frozen-lockfile'] },
   {
@@ -24,8 +26,12 @@ const phases = [
   },
   { name: 'lint:fix', cmd: 'pnpm', args: ['lint:fix'] },
   { name: 'build', cmd: 'pnpm', args: ['build'], env: qaBuildEnv },
-  { name: 'test', cmd: 'pnpm', args: ['exec', 'turbo', 'run', 'test', '--concurrency=100%'] },
-  { name: 'test:e2e', cmd: 'pnpm', args: ['test:e2e'] },
+  ...(skipTests
+    ? []
+    : [
+        { name: 'test', cmd: 'pnpm', args: ['exec', 'turbo', 'run', 'test', '--concurrency=100%'] },
+        { name: 'test:e2e', cmd: 'pnpm', args: ['test:e2e'] },
+      ]),
 ]
 
 for (const { name, cmd, args, env } of phases) {


### PR DESCRIPTION

- Add username to buildUserInfoSpec and UserInfoComponent (backend + frontend)
- Remove 'Tell me a joke' from assistant suggestions
- Restore chat-assistant E2E: use authenticatedPage, remove skip
- Chromium project depends on auth; update docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Brave Search web-search tool and support for showing usernames in user profiles.

* **Bug Fixes**
  * Enabled chat assistant e2e tests with authenticated flows.

* **Documentation**
  * Removed disabled/skipped specs notes and updated E2E and self-hosted LLM docs for new auth/provider and Brave Search guidance.

* **Tests**
  * Refactored chat e2e tests to use authenticated fixture and removed a "Tell me a joke" suggestion.

* **Chores**
  * CI/local run scripts adjusted to prefer Ollama and optional test-skip flag added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->