### PR TITLE
feat(auth): standardize OAuth callback URL resolution across providers

### DIFF
--- a/apps/docu/content/docs/architecture/authentication.mdx
+++ b/apps/docu/content/docs/architecture/authentication.mdx
@@ -115,19 +115,23 @@ OAuth sign-in uses provider authorization + callback flows and issues access + r
 **GitHub OAuth flow:**
 
 1. User clicks "Continue with GitHub" → client calls `useOAuthLogin` → `GET /auth/oauth/github/authorize-url` (direct to Fastify) → receives `{ redirectUrl }` → redirects to GitHub
-2. User authorizes on GitHub → GitHub redirects to `OAUTH_GITHUB_CALLBACK_URL` with `?code=&state=`
+2. User authorizes on GitHub → GitHub redirects to callback URL with `?code=&state=`
 3. Callback page (`/auth/callback/oauth/github`) calls `POST /auth/oauth/github/exchange` with `{ code, state }` → Fastify returns `{ token, refreshToken }`
 4. Callback page sets cookies and redirects to `/`
 
-**Setup:** Create a [GitHub OAuth App](https://github.com/settings/applications/new). Set callback URL to `http://localhost:3000/auth/callback/oauth/github` (dev) or your production URL. Add `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `OAUTH_GITHUB_CALLBACK_URL` to Fastify env.
+**Setup:** Create a [GitHub OAuth App](https://github.com/settings/applications/new). Set callback URL(s) to match your env. Add `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and either `OAUTH_GITHUB_CALLBACK_URL` (single) or `OAUTH_GITHUB_CALLBACK_URLS` (comma-separated) to Fastify env.
 
 ### OAuth (Google, Facebook, Twitter)
 
-**Google:** Two flows. **(1) One Tap (primary):** Uses [Google Identity Services](https://developers.google.com/identity/gsi/web) (GIS). Popup in top-right when user is logged into Google. Client POSTs `{ credential }` to `POST /auth/oauth/google/verify-id-token`. **(2) Redirect (fallback + linking):** When One Tap is blocked/dismissed or for account linking. `GET /auth/oauth/google/authorize-url?redirect_uri=` (optional) → callback → `POST /auth/oauth/google/exchange`. Client can send `redirect_uri` to choose which callback URL to use (must be in allowlist). **Setup:** One Tap: `GOOGLE_CLIENT_ID`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID`. Redirect/linking: add `GOOGLE_CLIENT_SECRET`, and either `OAUTH_GOOGLE_CALLBACK_URL` (single) or `OAUTH_GOOGLE_CALLBACK_URLS` (comma-separated for web + mobile).
+All OAuth providers support optional `redirect_uri` on authorize-url and link-authorize-url. When provided, it must exactly match one of the configured callback URLs. Default = first URL in the list. Use `OAUTH_*_CALLBACK_URLS` (comma-separated) for web + mobile; `OAUTH_*_CALLBACK_URL` (single) for backward compatibility.
 
-**Facebook:** Redirect flow like GitHub. `GET /auth/oauth/facebook/authorize-url` → `POST /auth/oauth/facebook/exchange`. Callback: `/auth/callback/oauth/facebook`. **Setup:** `FACEBOOK_CLIENT_ID`, `FACEBOOK_CLIENT_SECRET`, `OAUTH_FACEBOOK_CALLBACK_URL`.
+**Google:** Two flows. **(1) One Tap (primary):** Uses [Google Identity Services](https://developers.google.com/identity/gsi/web) (GIS). Popup in top-right when user is logged into Google. Client POSTs `{ credential }` to `POST /auth/oauth/google/verify-id-token`. **(2) Redirect (fallback + linking):** When One Tap is blocked/dismissed or for account linking. `GET /auth/oauth/google/authorize-url?redirect_uri=` (optional) → callback → `POST /auth/oauth/google/exchange`. **Setup:** One Tap: `GOOGLE_CLIENT_ID`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID`. Redirect/linking: add `GOOGLE_CLIENT_SECRET`, and either `OAUTH_GOOGLE_CALLBACK_URL` (single) or `OAUTH_GOOGLE_CALLBACK_URLS` (comma-separated).
 
-**Twitter (X):** OAuth 2.0 with PKCE. `GET /auth/oauth/twitter/authorize-url` (includes `code_challenge`) → `POST /auth/oauth/twitter/exchange` (includes `code_verifier` from verification `meta`). Callback: `/auth/callback/oauth/twitter`. **Setup:** `TWITTER_CLIENT_ID`, `TWITTER_CLIENT_SECRET`, `OAUTH_TWITTER_CALLBACK_URL`.
+**Facebook:** Redirect flow. `GET /auth/oauth/facebook/authorize-url?redirect_uri=` (optional) → `POST /auth/oauth/facebook/exchange`. Callback: `/auth/callback/oauth/facebook`. **Setup:** `FACEBOOK_CLIENT_ID`, `FACEBOOK_CLIENT_SECRET`, `OAUTH_FACEBOOK_CALLBACK_URL` or `OAUTH_FACEBOOK_CALLBACK_URLS`.
+
+**Twitter (X):** OAuth 2.0 with PKCE. `GET /auth/oauth/twitter/authorize-url?redirect_uri=` (optional) → `POST /auth/oauth/twitter/exchange`. Callback: `/auth/callback/oauth/twitter`. **Setup:** `TWITTER_CLIENT_ID`, `TWITTER_CLIENT_SECRET`, `OAUTH_TWITTER_CALLBACK_URL` or `OAUTH_TWITTER_CALLBACK_URLS`.
+
+**Provider console pitfalls:** Redirect URI must match exactly (no prefix, partial, or wildcard). Watch for trailing slash, HTTPS vs HTTP, and mobile scheme restrictions. Add each URL to the provider's allowed callback list.
 
 When a provider is not configured (503 `OAUTH_NOT_CONFIGURED`), the client shows a Sonner toast instead of redirecting.
 
@@ -135,7 +139,7 @@ When a provider is not configured (503 `OAUTH_NOT_CONFIGURED`), the client shows
 
 Logged-in users can link additional OAuth providers from Profile (Settings). Flow: `GET /auth/oauth/{provider}/link-authorize-url` (session/JWT required, no API key) → redirect to provider → callback → exchange with `oauth_link_state` → link account, return `{ token, refreshToken, redirectTo: "/settings?linked=ok" }`.
 
-- **Link-authorize-url:** Session/JWT required, no API key; rate limit 10/hour per user. Stores `oauth_link_state` with `meta.userId`. Google accepts optional query `redirect_uri` for mobile (must be in `OAUTH_GOOGLE_CALLBACK_URLS`).
+- **Link-authorize-url:** Session/JWT required, no API key; rate limit 10/hour per user. Stores `oauth_link_state` with `meta.userId`, `meta.redirectUri`. All providers accept optional query `redirect_uri` (must be in configured callback URLs).
 - **Exchange:** State lookup branches on `oauth_link_state` vs `oauth_state`. Link mode uses `meta.userId`; if provider already linked to another user → 409 `PROVIDER_ALREADY_LINKED`.
 - **Unlink:** `DELETE /account/link/oauth/:providerId` (Bearer). Guardrail: cannot unlink if it would leave no sign-in method (400 `LAST_SIGN_IN_METHOD`).
 - **Session user:** `GET /auth/session/user` returns `linkedAccounts: [{ providerId }]`.
@@ -301,8 +305,8 @@ All endpoints below are served by `apps/fastify`. The API does not set cookies; 
   - `POST /auth/magiclink/request` → `{ ok }`
   - `POST /auth/magiclink/verify` → `{ token, refreshToken }`
 - **OAuth (GitHub)**
-  - `GET /auth/oauth/github/authorize-url` → `{ redirectUrl }` (for client-side redirect; preferred)
-  - `GET /auth/oauth/github/authorize` → 302 redirect to GitHub (legacy)
+  - `GET /auth/oauth/github/authorize-url` → `{ redirectUrl }` (optional query: `redirect_uri`)
+  - `GET /auth/oauth/github/authorize` → 302 redirect to GitHub (legacy; optional query: `redirect_uri`)
   - `POST /auth/oauth/github/exchange` → `{ token, refreshToken }` (body: `{ code, state }`)
 - **OAuth (Google One Tap)**
   - `POST /auth/oauth/google/verify-id-token` → `{ token, refreshToken }` (body: `{ credential }`)
@@ -310,10 +314,10 @@ All endpoints below are served by `apps/fastify`. The API does not set cookies; 
   - `GET /auth/oauth/google/authorize-url` → `{ redirectUrl }` (optional query: `redirect_uri` — must be in allowlist)
   - `POST /auth/oauth/google/exchange` → `{ token, refreshToken, redirectTo? }` (body: `{ code, state }`)
 - **OAuth (Facebook)**
-  - `GET /auth/oauth/facebook/authorize-url` → `{ redirectUrl }`
+  - `GET /auth/oauth/facebook/authorize-url` → `{ redirectUrl }` (optional query: `redirect_uri`)
   - `POST /auth/oauth/facebook/exchange` → `{ token, refreshToken }` (body: `{ code, state }`)
 - **OAuth (Twitter)**
-  - `GET /auth/oauth/twitter/authorize-url` → `{ redirectUrl }` (PKCE)
+  - `GET /auth/oauth/twitter/authorize-url` → `{ redirectUrl }` (PKCE; optional query: `redirect_uri`)
   - `POST /auth/oauth/twitter/exchange` → `{ token, refreshToken }` (body: `{ code, state }`)
 - **Web3**
   - `GET /auth/web3/nonce` → `{ nonce }` (query: `chain`, `address`)
@@ -327,7 +331,7 @@ All endpoints below are served by `apps/fastify`. The API does not set cookies; 
   - `DELETE /account/link/wallet/:id` → `204` (unlink wallet by id from `linkedWallets`)
   - `POST /account/link/email/request` → `{ ok }` (body: `email`, `callbackUrl`)
   - `POST /account/link/email/verify` → `{ token, refreshToken }` (body: `token`)
-  - `GET /auth/oauth/{github,google,facebook,twitter}/link-authorize-url` → `{ redirectUrl }` (Session required; Google accepts optional query `redirect_uri` for mobile; rate limit 10/hour)
+  - `GET /auth/oauth/{github,google,facebook,twitter}/link-authorize-url` → `{ redirectUrl }` (Session required; optional query `redirect_uri` for all providers; rate limit 10/hour)
   - `DELETE /account/link/oauth/:providerId` → `204` (unlink OAuth provider)
 
 **Account link error codes**: `WALLET_ALREADY_LINKED`, `EMAIL_ALREADY_IN_USE`, `PROVIDER_ALREADY_LINKED`, `LAST_SIGN_IN_METHOD`

--- a/apps/fastify/.env-sample
+++ b/apps/fastify/.env-sample
@@ -24,7 +24,10 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 # Optional: GitHub OAuth (Sign in with GitHub)
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
+# Single callback URL (backward compat):
 # OAUTH_GITHUB_CALLBACK_URL=http://localhost:3000/auth/callback/oauth/github
+# Multiple callbacks for web + mobile (comma-separated):
+# OAUTH_GITHUB_CALLBACK_URLS=http://localhost:3000/auth/callback/oauth/github,yourapp://auth/callback
 
 # Optional: Google OAuth (One Tap popup + redirect fallback)
 # GOOGLE_CLIENT_ID=xxx.apps.googleusercontent.com
@@ -37,12 +40,18 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 # Optional: Facebook OAuth
 # FACEBOOK_CLIENT_ID=
 # FACEBOOK_CLIENT_SECRET=
+# Single callback URL (backward compat):
 # OAUTH_FACEBOOK_CALLBACK_URL=http://localhost:3000/auth/callback/oauth/facebook
+# Multiple callbacks (comma-separated):
+# OAUTH_FACEBOOK_CALLBACK_URLS=http://localhost:3000/auth/callback/oauth/facebook,yourapp://auth/callback
 
 # Optional: Twitter (X) OAuth
 # TWITTER_CLIENT_ID=
 # TWITTER_CLIENT_SECRET=
+# Single callback URL (backward compat):
 # OAUTH_TWITTER_CALLBACK_URL=http://localhost:3000/auth/callback/oauth/twitter
+# Multiple callbacks (comma-separated):
+# OAUTH_TWITTER_CALLBACK_URLS=http://localhost:3000/auth/callback/oauth/twitter,yourapp://auth/callback
 
 # CORS + URL allowlist. Default: * (any). Comma-separated origins to restrict.
 # ALLOWED_ORIGINS=https://app.example.com,https://localhost:3000

--- a/apps/fastify/openapi/openapi.json
+++ b/apps/fastify/openapi/openapi.json
@@ -2708,25 +2708,37 @@
                   "type": "object",
                   "required": [
                     "github",
+                    "githubHasRedirectConfig",
                     "google",
-                    "googleRedirect",
+                    "googleHasRedirectConfig",
                     "facebook",
-                    "twitter"
+                    "facebookHasRedirectConfig",
+                    "twitter",
+                    "twitterHasRedirectConfig"
                   ],
                   "properties": {
                     "github": {
                       "type": "boolean"
                     },
+                    "githubHasRedirectConfig": {
+                      "type": "boolean"
+                    },
                     "google": {
                       "type": "boolean"
                     },
-                    "googleRedirect": {
+                    "googleHasRedirectConfig": {
                       "type": "boolean"
                     },
                     "facebook": {
                       "type": "boolean"
                     },
+                    "facebookHasRedirectConfig": {
+                      "type": "boolean"
+                    },
                     "twitter": {
+                      "type": "boolean"
+                    },
+                    "twitterHasRedirectConfig": {
                       "type": "boolean"
                     }
                   }
@@ -2745,6 +2757,16 @@
           "auth"
         ],
         "description": "Return Facebook OAuth authorization URL for client-side redirect",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "redirect_uri",
+            "required": false
+          }
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -2758,6 +2780,28 @@
                   ],
                   "properties": {
                     "redirectUrl": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
                       "type": "string"
                     }
                   }
@@ -2990,6 +3034,16 @@
           "auth"
         ],
         "description": "Return Facebook OAuth URL for linking account (Bearer required)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "redirect_uri",
+            "required": false
+          }
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3007,6 +3061,28 @@
                   ],
                   "properties": {
                     "redirectUrl": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
                       "type": "string"
                     }
                   }
@@ -3091,6 +3167,16 @@
           "auth"
         ],
         "description": "Return GitHub OAuth authorization URL for client-side redirect",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "redirect_uri",
+            "required": false
+          }
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -3104,6 +3190,28 @@
                   ],
                   "properties": {
                     "redirectUrl": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
                       "type": "string"
                     }
                   }
@@ -3144,6 +3252,16 @@
           "auth"
         ],
         "description": "Redirect to GitHub OAuth authorization",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "redirect_uri",
+            "required": false
+          }
+        ],
         "security": [],
         "responses": {
           "302": {
@@ -3153,6 +3271,28 @@
                 "schema": {
                   "type": "string",
                   "description": "Redirect to GitHub"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
@@ -3360,6 +3500,16 @@
           "auth"
         ],
         "description": "Return GitHub OAuth URL for linking account (Bearer required)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "redirect_uri",
+            "required": false
+          }
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -3377,6 +3527,28 @@
                   ],
                   "properties": {
                     "redirectUrl": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
                       "type": "string"
                     }
                   }
@@ -3990,6 +4162,16 @@
           "auth"
         ],
         "description": "Return Twitter/X OAuth authorization URL for client-side redirect (PKCE)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "redirect_uri",
+            "required": false
+          }
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -4003,6 +4185,28 @@
                   ],
                   "properties": {
                     "redirectUrl": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
                       "type": "string"
                     }
                   }
@@ -4257,6 +4461,16 @@
           "auth"
         ],
         "description": "Return Twitter/X OAuth URL for linking account (Bearer required, PKCE)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "redirect_uri",
+            "required": false
+          }
+        ],
         "security": [
           {
             "bearerAuth": []
@@ -4274,6 +4488,28 @@
                   ],
                   "properties": {
                     "redirectUrl": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
                       "type": "string"
                     }
                   }

--- a/apps/fastify/src/lib/env.ts
+++ b/apps/fastify/src/lib/env.ts
@@ -2,6 +2,26 @@ import 'dotenv/config'
 import { createEnv } from '@t3-oss/env-core'
 import { z } from 'zod'
 
+function parseCallbackUrls(val: string | undefined): string[] | undefined {
+  if (!val) return undefined
+  const arr = val
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+  const result: string[] = []
+  for (const item of arr)
+    try {
+      const u = new URL(item)
+      if ((u.protocol !== 'http:' && u.protocol !== 'https:') || !u.hostname)
+        throw new Error('Invalid scheme or hostname')
+      result.push(item)
+    } catch {
+      throw new Error(`OAUTH_*_CALLBACK_URLS: invalid URL "${item}"`)
+    }
+
+  return result.length > 0 ? result : undefined
+}
+
 const hex64 = z
   .string()
   .length(64)
@@ -92,14 +112,7 @@ export const env = createEnv({
     OAUTH_GITHUB_CALLBACK_URLS: z
       .string()
       .optional()
-      .transform(val =>
-        val
-          ? val
-              .split(',')
-              .map(s => s.trim())
-              .filter(Boolean)
-          : undefined,
-      ),
+      .transform(val => parseCallbackUrls(val)),
     // Google OAuth (optional - One Tap + redirect fallback)
     GOOGLE_CLIENT_ID: z.string().min(1).optional(),
     GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
@@ -107,14 +120,7 @@ export const env = createEnv({
     OAUTH_GOOGLE_CALLBACK_URLS: z
       .string()
       .optional()
-      .transform(val =>
-        val
-          ? val
-              .split(',')
-              .map(s => s.trim())
-              .filter(Boolean)
-          : undefined,
-      ),
+      .transform(val => parseCallbackUrls(val)),
     // Facebook OAuth (optional)
     FACEBOOK_CLIENT_ID: z.string().min(1).optional(),
     FACEBOOK_CLIENT_SECRET: z.string().min(1).optional(),
@@ -122,14 +128,7 @@ export const env = createEnv({
     OAUTH_FACEBOOK_CALLBACK_URLS: z
       .string()
       .optional()
-      .transform(val =>
-        val
-          ? val
-              .split(',')
-              .map(s => s.trim())
-              .filter(Boolean)
-          : undefined,
-      ),
+      .transform(val => parseCallbackUrls(val)),
     // Twitter OAuth (optional, PKCE)
     TWITTER_CLIENT_ID: z.string().min(1).optional(),
     TWITTER_CLIENT_SECRET: z.string().min(1).optional(),
@@ -137,14 +136,7 @@ export const env = createEnv({
     OAUTH_TWITTER_CALLBACK_URLS: z
       .string()
       .optional()
-      .transform(val =>
-        val
-          ? val
-              .split(',')
-              .map(s => s.trim())
-              .filter(Boolean)
-          : undefined,
-      ),
+      .transform(val => parseCallbackUrls(val)),
     ALLOWED_ORIGINS: z
       .string()
       .default('*')

--- a/apps/fastify/src/lib/env.ts
+++ b/apps/fastify/src/lib/env.ts
@@ -89,6 +89,17 @@ export const env = createEnv({
     GITHUB_CLIENT_ID: z.string().min(1).optional(),
     GITHUB_CLIENT_SECRET: z.string().min(1).optional(),
     OAUTH_GITHUB_CALLBACK_URL: z.string().url().optional(),
+    OAUTH_GITHUB_CALLBACK_URLS: z
+      .string()
+      .optional()
+      .transform(val =>
+        val
+          ? val
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+          : undefined,
+      ),
     // Google OAuth (optional - One Tap + redirect fallback)
     GOOGLE_CLIENT_ID: z.string().min(1).optional(),
     GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
@@ -108,10 +119,32 @@ export const env = createEnv({
     FACEBOOK_CLIENT_ID: z.string().min(1).optional(),
     FACEBOOK_CLIENT_SECRET: z.string().min(1).optional(),
     OAUTH_FACEBOOK_CALLBACK_URL: z.string().url().optional(),
+    OAUTH_FACEBOOK_CALLBACK_URLS: z
+      .string()
+      .optional()
+      .transform(val =>
+        val
+          ? val
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+          : undefined,
+      ),
     // Twitter OAuth (optional, PKCE)
     TWITTER_CLIENT_ID: z.string().min(1).optional(),
     TWITTER_CLIENT_SECRET: z.string().min(1).optional(),
     OAUTH_TWITTER_CALLBACK_URL: z.string().url().optional(),
+    OAUTH_TWITTER_CALLBACK_URLS: z
+      .string()
+      .optional()
+      .transform(val =>
+        val
+          ? val
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+          : undefined,
+      ),
     ALLOWED_ORIGINS: z
       .string()
       .default('*')

--- a/apps/fastify/src/lib/oauth-shared.ts
+++ b/apps/fastify/src/lib/oauth-shared.ts
@@ -1,0 +1,40 @@
+/** Intentionally extensible for future providers (e.g. nonce, provider-specific fields). */
+export interface OAuthStateMeta {
+  redirectUri?: string
+  codeVerifier?: string
+  userId?: string
+  mode?: 'login' | 'link'
+}
+
+export type ResolveOAuthCallbackUrlResult =
+  | { ok: true; defaultUrl: string; redirectUri: string; allowedUrls: string[] }
+  | { ok: false; error: 'NOT_CONFIGURED' | 'INVALID_REDIRECT_URI' }
+
+/**
+ * Resolve OAuth callback URL from allowed list and optional client request.
+ * defaultUrl = allowedUrls[0]. If requestedRedirectUri provided: exact string match
+ * against allowedUrls; if match use it else INVALID_REDIRECT_URI. If not provided, use defaultUrl.
+ */
+export function resolveOAuthCallbackUrl(opts: {
+  allowedUrls: string[]
+  requestedRedirectUri?: string
+}): ResolveOAuthCallbackUrlResult {
+  const { allowedUrls, requestedRedirectUri } = opts
+  if (allowedUrls.length === 0) return { ok: false, error: 'NOT_CONFIGURED' }
+  const defaultUrl = allowedUrls[0]
+  if (!requestedRedirectUri) return { ok: true, defaultUrl, redirectUri: defaultUrl, allowedUrls }
+  const match = allowedUrls.includes(requestedRedirectUri)
+  if (!match) return { ok: false, error: 'INVALID_REDIRECT_URI' }
+  return { ok: true, defaultUrl, redirectUri: requestedRedirectUri, allowedUrls }
+}
+
+/** Build allowed callback URLs from env: OAUTH_*_CALLBACK_URLS (comma-separated) or OAUTH_*_CALLBACK_URL (single). */
+export function getOAuthAllowedCallbackUrls(opts: {
+  urls?: string[]
+  singleUrl?: string
+}): string[] {
+  const { urls, singleUrl } = opts
+  if (urls && urls.length > 0) return urls
+  if (singleUrl) return [singleUrl]
+  return []
+}

--- a/apps/fastify/src/lib/oauth-twitter.ts
+++ b/apps/fastify/src/lib/oauth-twitter.ts
@@ -142,12 +142,11 @@ async function runTwitterExchangeTxForUser(params: {
 export async function fetchTwitterOAuthData(input: {
   code: string
   codeVerifier: string
-  oauthTwitterCallbackUrl: string
+  redirectUri: string
   twitterClientId: string
   twitterClientSecret: string
 }): Promise<{ accountId: string; name: string; accountData: TwitterAccountData }> {
-  const { code, codeVerifier, oauthTwitterCallbackUrl, twitterClientId, twitterClientSecret } =
-    input
+  const { code, codeVerifier, redirectUri, twitterClientId, twitterClientSecret } = input
   const fetchTimeoutMs = 15_000
   const tokenBody = new URLSearchParams({
     /* biome-ignore lint/style/useNamingConvention: OAuth spec uses snake_case */
@@ -156,7 +155,7 @@ export async function fetchTwitterOAuthData(input: {
     /* biome-ignore lint/style/useNamingConvention: OAuth spec uses snake_case */
     code_verifier: codeVerifier,
     /* biome-ignore lint/style/useNamingConvention: OAuth spec uses snake_case */
-    redirect_uri: oauthTwitterCallbackUrl,
+    redirect_uri: redirectUri,
   })
   const basicAuth = Buffer.from(`${twitterClientId}:${twitterClientSecret}`).toString('base64')
   const tokenRes = await fetch('https://api.x.com/2/oauth2/token', {

--- a/apps/fastify/src/routes/auth/oauth/facebook/authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/facebook/authorize-url.ts
@@ -6,10 +6,18 @@ import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
 const AuthorizeUrlResponseSchema = Type.Object({
   redirectUrl: Type.String(),
+})
+
+const AuthorizeUrlQuerystringSchema = Type.Object({
+  redirect_uri: Type.Optional(Type.String()),
 })
 
 const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
@@ -22,21 +30,40 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         summary: 'Facebook OAuth authorize URL',
         tags: ['auth'],
         security: [],
+        querystring: AuthorizeUrlQuerystringSchema,
         response: {
           200: AuthorizeUrlResponseSchema,
+          400: ErrorResponseSchema,
           503: ErrorResponseSchema,
         },
       },
     },
-    async (_request, reply) => {
+    async (request, reply) => {
       const facebookClientId = env.FACEBOOK_CLIENT_ID
       const facebookClientSecret = env.FACEBOOK_CLIENT_SECRET
-      const oauthFacebookCallbackUrl = env.OAUTH_FACEBOOK_CALLBACK_URL
-      if (!facebookClientId || !facebookClientSecret || !oauthFacebookCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_FACEBOOK_CALLBACK_URLS,
+        singleUrl: env.OAUTH_FACEBOOK_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'Facebook OAuth is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!facebookClientId || !facebookClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Facebook OAuth is not configured',
         })
+      const { redirectUri } = resolved
 
       const state = randomUUID() + randomUUID().replace(/-/g, '')
       const stateHash = hashToken(state)
@@ -48,12 +75,13 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         type: 'oauth_state',
         identifier: stateHash,
         value: stateHash,
+        meta: { redirectUri },
         expiresAt,
       })
 
       const redirectUrl = new URL('https://www.facebook.com/v21.0/dialog/oauth')
       redirectUrl.searchParams.set('client_id', facebookClientId)
-      redirectUrl.searchParams.set('redirect_uri', oauthFacebookCallbackUrl)
+      redirectUrl.searchParams.set('redirect_uri', redirectUri)
       redirectUrl.searchParams.set('scope', 'email,public_profile')
       redirectUrl.searchParams.set('state', state)
 

--- a/apps/fastify/src/routes/auth/oauth/facebook/exchange.ts
+++ b/apps/fastify/src/routes/auth/oauth/facebook/exchange.ts
@@ -14,6 +14,7 @@ import {
   hashToken,
 } from '../../../../lib/jwt.js'
 import { validateAndConsumeOAuthState } from '../../../../lib/oauth-exchange-state.js'
+import { getOAuthAllowedCallbackUrls, type OAuthStateMeta } from '../../../../lib/oauth-shared.js'
 import { findOrCreateUserByEmail } from '../../../../lib/oauth-user.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
@@ -61,8 +62,12 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
     async (request, reply) => {
       const facebookClientId = env.FACEBOOK_CLIENT_ID
       const facebookClientSecret = env.FACEBOOK_CLIENT_SECRET
-      const oauthFacebookCallbackUrl = env.OAUTH_FACEBOOK_CALLBACK_URL
-      if (!facebookClientId || !facebookClientSecret || !oauthFacebookCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_FACEBOOK_CALLBACK_URLS,
+        singleUrl: env.OAUTH_FACEBOOK_CALLBACK_URL,
+      })
+      const defaultUrl = allowedUrls[0]
+      if (!facebookClientId || !facebookClientSecret || !defaultUrl)
         return reply.code(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Facebook OAuth is not configured',
@@ -74,12 +79,19 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
       const db = await getDb()
       const validated = await validateAndConsumeOAuthState({ db, stateHash, request, reply })
       if (!validated.ok) return
-      const { isLinkMode, linkUserId } = validated
+      const { isLinkMode, linkUserId, stateRecord } = validated
+      const meta = stateRecord.meta as OAuthStateMeta | undefined
+      const redirectUri = meta?.redirectUri ?? defaultUrl
+      if (!allowedUrls.includes(redirectUri))
+        return reply.code(401).send({
+          code: 'INVALID_STATE',
+          message: 'Invalid or tampered redirect URI',
+        })
 
       const tokenUrl = new URL('https://graph.facebook.com/v21.0/oauth/access_token')
       tokenUrl.searchParams.set('client_id', facebookClientId)
       tokenUrl.searchParams.set('client_secret', facebookClientSecret)
-      tokenUrl.searchParams.set('redirect_uri', oauthFacebookCallbackUrl)
+      tokenUrl.searchParams.set('redirect_uri', redirectUri)
       tokenUrl.searchParams.set('code', code)
 
       const fetchTimeoutMs = 15_000

--- a/apps/fastify/src/routes/auth/oauth/facebook/link-authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/facebook/link-authorize-url.ts
@@ -7,12 +7,20 @@ import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
 const linkAuthorizeUrlPerUserPerHour = 10
 
 const AuthorizeUrlResponseSchema = Type.Object({
   redirectUrl: Type.String(),
+})
+
+const LinkAuthorizeUrlQuerystringSchema = Type.Object({
+  redirect_uri: Type.Optional(Type.String()),
 })
 
 const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
@@ -25,9 +33,11 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         summary: 'Facebook OAuth link authorize URL',
         tags: ['auth'],
         security: [{ bearerAuth: [] }],
+        querystring: LinkAuthorizeUrlQuerystringSchema,
         response: {
           200: AuthorizeUrlResponseSchema,
           401: ErrorResponseSchema,
+          400: ErrorResponseSchema,
           429: ErrorResponseSchema,
           503: ErrorResponseSchema,
         },
@@ -42,12 +52,29 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
 
       const facebookClientId = env.FACEBOOK_CLIENT_ID
       const facebookClientSecret = env.FACEBOOK_CLIENT_SECRET
-      const oauthFacebookCallbackUrl = env.OAUTH_FACEBOOK_CALLBACK_URL
-      if (!facebookClientId || !facebookClientSecret || !oauthFacebookCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_FACEBOOK_CALLBACK_URLS,
+        singleUrl: env.OAUTH_FACEBOOK_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'Facebook OAuth is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!facebookClientId || !facebookClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Facebook OAuth is not configured',
         })
+      const { redirectUri } = resolved
 
       const userId = request.session.user.id
       const db = await getDb()
@@ -77,13 +104,13 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         type: 'oauth_link_state',
         identifier: `link:${userId}`,
         value: stateHash,
-        meta: { userId },
+        meta: { userId, redirectUri },
         expiresAt,
       })
 
       const redirectUrl = new URL('https://www.facebook.com/v21.0/dialog/oauth')
       redirectUrl.searchParams.set('client_id', facebookClientId)
-      redirectUrl.searchParams.set('redirect_uri', oauthFacebookCallbackUrl)
+      redirectUrl.searchParams.set('redirect_uri', redirectUri)
       redirectUrl.searchParams.set('scope', 'email,public_profile')
       redirectUrl.searchParams.set('state', state)
 

--- a/apps/fastify/src/routes/auth/oauth/github/authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/github/authorize-url.ts
@@ -6,10 +6,18 @@ import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
 const AuthorizeUrlResponseSchema = Type.Object({
   redirectUrl: Type.String(),
+})
+
+const AuthorizeUrlQuerystringSchema = Type.Object({
+  redirect_uri: Type.Optional(Type.String()),
 })
 
 const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
@@ -22,20 +30,39 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         summary: 'GitHub OAuth authorize URL',
         tags: ['auth'],
         security: [],
+        querystring: AuthorizeUrlQuerystringSchema,
         response: {
           200: AuthorizeUrlResponseSchema,
+          400: ErrorResponseSchema,
           503: ErrorResponseSchema,
         },
       },
     },
-    async (_request, reply) => {
+    async (request, reply) => {
       const githubClientId = env.GITHUB_CLIENT_ID
-      const oauthGithubCallbackUrl = env.OAUTH_GITHUB_CALLBACK_URL
-      if (!githubClientId || !oauthGithubCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_GITHUB_CALLBACK_URLS,
+        singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'GitHub OAuth is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!githubClientId)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'GitHub OAuth is not configured',
         })
+      const { redirectUri } = resolved
 
       const state = randomUUID() + randomUUID().replace(/-/g, '')
       const stateHash = hashToken(state)
@@ -47,12 +74,13 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         type: 'oauth_state',
         identifier: stateHash,
         value: stateHash,
+        meta: { redirectUri },
         expiresAt,
       })
 
       const redirectUrl = new URL('https://github.com/login/oauth/authorize')
       redirectUrl.searchParams.set('client_id', githubClientId)
-      redirectUrl.searchParams.set('redirect_uri', oauthGithubCallbackUrl)
+      redirectUrl.searchParams.set('redirect_uri', redirectUri)
       redirectUrl.searchParams.set('scope', 'user:email')
       redirectUrl.searchParams.set('state', state)
 

--- a/apps/fastify/src/routes/auth/oauth/github/authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/github/authorize-url.ts
@@ -40,13 +40,14 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
     },
     async (request, reply) => {
       const githubClientId = env.GITHUB_CLIENT_ID
+      const githubClientSecret = env.GITHUB_CLIENT_SECRET
       const allowedUrls = getOAuthAllowedCallbackUrls({
         urls: env.OAUTH_GITHUB_CALLBACK_URLS,
         singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
       })
       const resolved = resolveOAuthCallbackUrl({
         allowedUrls,
-        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+        requestedRedirectUri: request.query.redirect_uri,
       })
       if (!resolved.ok)
         return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
@@ -57,7 +58,7 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
               ? 'GitHub OAuth is not configured'
               : 'redirect_uri must be one of the configured callback URLs',
         })
-      if (!githubClientId)
+      if (!githubClientId || !githubClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'GitHub OAuth is not configured',

--- a/apps/fastify/src/routes/auth/oauth/github/authorize.ts
+++ b/apps/fastify/src/routes/auth/oauth/github/authorize.ts
@@ -36,6 +36,7 @@ const oauthAuthorizeRoute: FastifyPluginAsync = async fastify => {
     },
     async (request, reply) => {
       const githubClientId = env.GITHUB_CLIENT_ID
+      const githubClientSecret = env.GITHUB_CLIENT_SECRET
       const allowedUrls = getOAuthAllowedCallbackUrls({
         urls: env.OAUTH_GITHUB_CALLBACK_URLS,
         singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
@@ -53,7 +54,7 @@ const oauthAuthorizeRoute: FastifyPluginAsync = async fastify => {
               ? 'GitHub OAuth is not configured'
               : 'redirect_uri must be one of the configured callback URLs',
         })
-      if (!githubClientId)
+      if (!githubClientId || !githubClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'GitHub OAuth is not configured',

--- a/apps/fastify/src/routes/auth/oauth/github/authorize.ts
+++ b/apps/fastify/src/routes/auth/oauth/github/authorize.ts
@@ -42,7 +42,7 @@ const oauthAuthorizeRoute: FastifyPluginAsync = async fastify => {
       })
       const resolved = resolveOAuthCallbackUrl({
         allowedUrls,
-        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+        requestedRedirectUri: request.query.redirect_uri,
       })
       if (!resolved.ok)
         return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({

--- a/apps/fastify/src/routes/auth/oauth/github/authorize.ts
+++ b/apps/fastify/src/routes/auth/oauth/github/authorize.ts
@@ -1,11 +1,20 @@
 import { randomUUID } from 'node:crypto'
 import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
+import { Type } from '@sinclair/typebox'
 import type { FastifyPluginAsync } from 'fastify'
 import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
+
+const AuthorizeQuerystringSchema = Type.Object({
+  redirect_uri: Type.Optional(Type.String()),
+})
 
 const oauthAuthorizeRoute: FastifyPluginAsync = async fastify => {
   fastify.withTypeProvider<TypeBoxTypeProvider>().get(
@@ -17,20 +26,39 @@ const oauthAuthorizeRoute: FastifyPluginAsync = async fastify => {
         summary: 'GitHub OAuth authorize',
         tags: ['auth'],
         security: [],
+        querystring: AuthorizeQuerystringSchema,
         response: {
           302: { type: 'string', description: 'Redirect to GitHub' },
+          400: ErrorResponseSchema,
           503: ErrorResponseSchema,
         },
       },
     },
-    async (_request, reply) => {
+    async (request, reply) => {
       const githubClientId = env.GITHUB_CLIENT_ID
-      const oauthGithubCallbackUrl = env.OAUTH_GITHUB_CALLBACK_URL
-      if (!githubClientId || !oauthGithubCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_GITHUB_CALLBACK_URLS,
+        singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'GitHub OAuth is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!githubClientId)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'GitHub OAuth is not configured',
         })
+      const { redirectUri } = resolved
 
       const state = randomUUID() + randomUUID().replace(/-/g, '')
       const stateHash = hashToken(state)
@@ -42,12 +70,13 @@ const oauthAuthorizeRoute: FastifyPluginAsync = async fastify => {
         type: 'oauth_state',
         identifier: stateHash,
         value: stateHash,
+        meta: { redirectUri },
         expiresAt,
       })
 
       const redirectUrl = new URL('https://github.com/login/oauth/authorize')
       redirectUrl.searchParams.set('client_id', githubClientId)
-      redirectUrl.searchParams.set('redirect_uri', oauthGithubCallbackUrl)
+      redirectUrl.searchParams.set('redirect_uri', redirectUri)
       redirectUrl.searchParams.set('scope', 'user:email')
       redirectUrl.searchParams.set('state', state)
 

--- a/apps/fastify/src/routes/auth/oauth/github/exchange.ts
+++ b/apps/fastify/src/routes/auth/oauth/github/exchange.ts
@@ -14,6 +14,7 @@ import {
   hashToken,
 } from '../../../../lib/jwt.js'
 import { validateAndConsumeOAuthState } from '../../../../lib/oauth-exchange-state.js'
+import { getOAuthAllowedCallbackUrls, type OAuthStateMeta } from '../../../../lib/oauth-shared.js'
 import { findOrCreateUserByEmail } from '../../../../lib/oauth-user.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
@@ -61,8 +62,12 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
     async (request, reply) => {
       const githubClientId = env.GITHUB_CLIENT_ID
       const githubClientSecret = env.GITHUB_CLIENT_SECRET
-      const oauthGithubCallbackUrl = env.OAUTH_GITHUB_CALLBACK_URL
-      if (!githubClientId || !githubClientSecret || !oauthGithubCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_GITHUB_CALLBACK_URLS,
+        singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
+      })
+      const defaultUrl = allowedUrls[0]
+      if (!githubClientId || !githubClientSecret || !defaultUrl)
         return reply.code(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'GitHub OAuth is not configured',
@@ -74,7 +79,14 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
       const db = await getDb()
       const validated = await validateAndConsumeOAuthState({ db, stateHash, request, reply })
       if (!validated.ok) return
-      const { isLinkMode, linkUserId } = validated
+      const { isLinkMode, linkUserId, stateRecord } = validated
+      const meta = stateRecord.meta as OAuthStateMeta | undefined
+      const redirectUri = meta?.redirectUri ?? defaultUrl
+      if (!allowedUrls.includes(redirectUri))
+        return reply.code(401).send({
+          code: 'INVALID_STATE',
+          message: 'Invalid or tampered redirect URI',
+        })
 
       const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
         method: 'POST',
@@ -86,7 +98,7 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
           client_id: githubClientId,
           client_secret: githubClientSecret,
           code,
-          redirect_uri: oauthGithubCallbackUrl,
+          redirect_uri: redirectUri,
         }),
       })
 

--- a/apps/fastify/src/routes/auth/oauth/github/link-authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/github/link-authorize-url.ts
@@ -51,13 +51,14 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         })
 
       const githubClientId = env.GITHUB_CLIENT_ID
+      const githubClientSecret = env.GITHUB_CLIENT_SECRET
       const allowedUrls = getOAuthAllowedCallbackUrls({
         urls: env.OAUTH_GITHUB_CALLBACK_URLS,
         singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
       })
       const resolved = resolveOAuthCallbackUrl({
         allowedUrls,
-        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+        requestedRedirectUri: request.query.redirect_uri,
       })
       if (!resolved.ok)
         return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
@@ -68,7 +69,7 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
               ? 'GitHub OAuth is not configured'
               : 'redirect_uri must be one of the configured callback URLs',
         })
-      if (!githubClientId)
+      if (!githubClientId || !githubClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'GitHub OAuth is not configured',

--- a/apps/fastify/src/routes/auth/oauth/github/link-authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/github/link-authorize-url.ts
@@ -7,12 +7,20 @@ import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
 const linkAuthorizeUrlPerUserPerHour = 10
 
 const AuthorizeUrlResponseSchema = Type.Object({
   redirectUrl: Type.String(),
+})
+
+const LinkAuthorizeUrlQuerystringSchema = Type.Object({
+  redirect_uri: Type.Optional(Type.String()),
 })
 
 const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
@@ -25,9 +33,11 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         summary: 'GitHub OAuth link authorize URL',
         tags: ['auth'],
         security: [{ bearerAuth: [] }],
+        querystring: LinkAuthorizeUrlQuerystringSchema,
         response: {
           200: AuthorizeUrlResponseSchema,
           401: ErrorResponseSchema,
+          400: ErrorResponseSchema,
           429: ErrorResponseSchema,
           503: ErrorResponseSchema,
         },
@@ -41,12 +51,29 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         })
 
       const githubClientId = env.GITHUB_CLIENT_ID
-      const oauthGithubCallbackUrl = env.OAUTH_GITHUB_CALLBACK_URL
-      if (!githubClientId || !oauthGithubCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_GITHUB_CALLBACK_URLS,
+        singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'GitHub OAuth is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!githubClientId)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'GitHub OAuth is not configured',
         })
+      const { redirectUri } = resolved
 
       const userId = request.session.user.id
       const db = await getDb()
@@ -76,13 +103,13 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         type: 'oauth_link_state',
         identifier: `link:${userId}`,
         value: stateHash,
-        meta: { userId },
+        meta: { userId, redirectUri },
         expiresAt,
       })
 
       const redirectUrl = new URL('https://github.com/login/oauth/authorize')
       redirectUrl.searchParams.set('client_id', githubClientId)
-      redirectUrl.searchParams.set('redirect_uri', oauthGithubCallbackUrl)
+      redirectUrl.searchParams.set('redirect_uri', redirectUri)
       redirectUrl.searchParams.set('scope', 'user:email')
       redirectUrl.searchParams.set('state', state)
 

--- a/apps/fastify/src/routes/auth/oauth/google/authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/google/authorize-url.ts
@@ -6,6 +6,10 @@ import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
 const AuthorizeUrlResponseSchema = Type.Object({
@@ -45,27 +49,29 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
     async (request, reply) => {
       const googleClientId = env.GOOGLE_CLIENT_ID
       const googleClientSecret = env.GOOGLE_CLIENT_SECRET
-      const allowedUrls =
-        env.OAUTH_GOOGLE_CALLBACK_URLS ??
-        (env.OAUTH_GOOGLE_CALLBACK_URL ? [env.OAUTH_GOOGLE_CALLBACK_URL] : [])
-      const defaultUrl = allowedUrls[0]
-      if (!googleClientId || !googleClientSecret || !defaultUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_GOOGLE_CALLBACK_URLS,
+        singleUrl: env.OAUTH_GOOGLE_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'Google OAuth redirect is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!googleClientId || !googleClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Google OAuth redirect is not configured',
         })
-
-      const requested = (request.query as { redirect_uri?: string })?.redirect_uri
-      const redirectUri = requested
-        ? allowedUrls.includes(requested)
-          ? requested
-          : null
-        : defaultUrl
-      if (!redirectUri)
-        return reply.status(400).send({
-          code: 'INVALID_REDIRECT_URI',
-          message: 'redirect_uri must be one of the configured callback URLs',
-        })
+      const { redirectUri } = resolved
 
       const state = randomUUID() + randomUUID().replace(/-/g, '')
       const stateHash = hashToken(state)

--- a/apps/fastify/src/routes/auth/oauth/google/exchange.ts
+++ b/apps/fastify/src/routes/auth/oauth/google/exchange.ts
@@ -100,6 +100,7 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
           code: 'INVALID_STATE',
           message: 'Invalid or tampered redirect URI',
         })
+      // preConsumeCheck guarantees codeVerifier; this check narrows the type for TS
       const codeVerifier = meta?.codeVerifier
       if (!codeVerifier)
         return reply.code(401).send({

--- a/apps/fastify/src/routes/auth/oauth/google/exchange.ts
+++ b/apps/fastify/src/routes/auth/oauth/google/exchange.ts
@@ -19,6 +19,7 @@ import {
   fetchGoogleUserInfo,
   type GoogleTokenResponse,
 } from '../../../../lib/oauth-google.js'
+import { getOAuthAllowedCallbackUrls, type OAuthStateMeta } from '../../../../lib/oauth-shared.js'
 import { findOrCreateUserByEmail } from '../../../../lib/oauth-user.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 import { buildTokenExchangeError, buildUserInfoError, toAllowedStatus } from './exchange-helpers.js'
@@ -60,9 +61,10 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
     async (request, reply) => {
       const googleClientId = env.GOOGLE_CLIENT_ID
       const googleClientSecret = env.GOOGLE_CLIENT_SECRET
-      const allowedUrls =
-        env.OAUTH_GOOGLE_CALLBACK_URLS ??
-        (env.OAUTH_GOOGLE_CALLBACK_URL ? [env.OAUTH_GOOGLE_CALLBACK_URL] : [])
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_GOOGLE_CALLBACK_URLS,
+        singleUrl: env.OAUTH_GOOGLE_CALLBACK_URL,
+      })
       const defaultUrl = allowedUrls[0]
       if (!googleClientId || !googleClientSecret || !defaultUrl)
         return reply.code(503).send({
@@ -91,13 +93,14 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
           code: 'INVALID_STATE',
           message: 'Link mode requires user ID',
         })
-      const redirectUri = stateRecord.meta?.redirectUri ?? defaultUrl
+      const meta = stateRecord.meta as OAuthStateMeta | undefined
+      const redirectUri = meta?.redirectUri ?? defaultUrl
       if (!allowedUrls.includes(redirectUri))
         return reply.code(401).send({
           code: 'INVALID_STATE',
           message: 'Invalid or tampered redirect URI',
         })
-      const codeVerifier = stateRecord.meta?.codeVerifier
+      const codeVerifier = meta?.codeVerifier
       if (!codeVerifier)
         return reply.code(401).send({
           code: 'INVALID_STATE',

--- a/apps/fastify/src/routes/auth/oauth/google/link-authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/google/link-authorize-url.ts
@@ -7,6 +7,10 @@ import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
 const linkAuthorizeUrlPerUserPerHour = 10
@@ -56,27 +60,29 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
 
       const googleClientId = env.GOOGLE_CLIENT_ID
       const googleClientSecret = env.GOOGLE_CLIENT_SECRET
-      const allowedUrls =
-        env.OAUTH_GOOGLE_CALLBACK_URLS ??
-        (env.OAUTH_GOOGLE_CALLBACK_URL ? [env.OAUTH_GOOGLE_CALLBACK_URL] : [])
-      const defaultUrl = allowedUrls[0]
-      if (!googleClientId || !googleClientSecret || !defaultUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_GOOGLE_CALLBACK_URLS,
+        singleUrl: env.OAUTH_GOOGLE_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'Google OAuth redirect is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!googleClientId || !googleClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Google OAuth redirect is not configured',
         })
-
-      const requested = (request.query as { redirect_uri?: string })?.redirect_uri
-      const redirectUri = requested
-        ? allowedUrls.includes(requested)
-          ? requested
-          : null
-        : defaultUrl
-      if (!redirectUri)
-        return reply.status(400).send({
-          code: 'INVALID_REDIRECT_URI',
-          message: 'redirect_uri must be one of the configured callback URLs',
-        })
+      const { redirectUri } = resolved
 
       const userId = request.session.user.id
       const db = await getDb()

--- a/apps/fastify/src/routes/auth/oauth/providers.test.ts
+++ b/apps/fastify/src/routes/auth/oauth/providers.test.ts
@@ -10,15 +10,21 @@ describe('GET /auth/oauth/providers', () => {
     expect(res.statusCode).toBe(200)
     const body = res.json() as {
       github: boolean
+      githubHasRedirectConfig: boolean
       google: boolean
-      googleRedirect: boolean
+      googleHasRedirectConfig: boolean
       facebook: boolean
+      facebookHasRedirectConfig: boolean
       twitter: boolean
+      twitterHasRedirectConfig: boolean
     }
     expect(typeof body.github).toBe('boolean')
+    expect(typeof body.githubHasRedirectConfig).toBe('boolean')
     expect(typeof body.google).toBe('boolean')
-    expect(typeof body.googleRedirect).toBe('boolean')
+    expect(typeof body.googleHasRedirectConfig).toBe('boolean')
     expect(typeof body.facebook).toBe('boolean')
+    expect(typeof body.facebookHasRedirectConfig).toBe('boolean')
     expect(typeof body.twitter).toBe('boolean')
+    expect(typeof body.twitterHasRedirectConfig).toBe('boolean')
   })
 })

--- a/apps/fastify/src/routes/auth/oauth/providers.ts
+++ b/apps/fastify/src/routes/auth/oauth/providers.ts
@@ -2,13 +2,28 @@ import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
 import { Type } from '@sinclair/typebox'
 import type { FastifyPluginAsync } from 'fastify'
 import { env } from '../../../lib/env.js'
+import { getOAuthAllowedCallbackUrls } from '../../../lib/oauth-shared.js'
+
+function hasRedirectConfig(opts: {
+  urls?: string[]
+  singleUrl?: string
+  clientId?: string
+  clientSecret?: string
+}): boolean {
+  const { urls, singleUrl, clientId, clientSecret } = opts
+  const allowedUrls = getOAuthAllowedCallbackUrls({ urls, singleUrl })
+  return Boolean(clientId) && Boolean(clientSecret) && allowedUrls.length > 0
+}
 
 const ProvidersResponseSchema = Type.Object({
   github: Type.Boolean(),
+  githubHasRedirectConfig: Type.Boolean(),
   google: Type.Boolean(),
-  googleRedirect: Type.Boolean(),
+  googleHasRedirectConfig: Type.Boolean(),
   facebook: Type.Boolean(),
+  facebookHasRedirectConfig: Type.Boolean(),
   twitter: Type.Boolean(),
+  twitterHasRedirectConfig: Type.Boolean(),
 })
 
 const oauthProvidersRoute: FastifyPluginAsync = async fastify => {
@@ -31,24 +46,49 @@ const oauthProvidersRoute: FastifyPluginAsync = async fastify => {
         github:
           Boolean(env.GITHUB_CLIENT_ID) &&
           Boolean(env.GITHUB_CLIENT_SECRET) &&
-          Boolean(env.OAUTH_GITHUB_CALLBACK_URL),
+          getOAuthAllowedCallbackUrls({
+            urls: env.OAUTH_GITHUB_CALLBACK_URLS,
+            singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
+          }).length > 0,
+        githubHasRedirectConfig: hasRedirectConfig({
+          urls: env.OAUTH_GITHUB_CALLBACK_URLS,
+          singleUrl: env.OAUTH_GITHUB_CALLBACK_URL,
+          clientId: env.GITHUB_CLIENT_ID,
+          clientSecret: env.GITHUB_CLIENT_SECRET,
+        }),
         google: Boolean(env.GOOGLE_CLIENT_ID),
-        googleRedirect: (() => {
-          const urls =
-            env.OAUTH_GOOGLE_CALLBACK_URLS ??
-            (env.OAUTH_GOOGLE_CALLBACK_URL ? [env.OAUTH_GOOGLE_CALLBACK_URL] : [])
-          return (
-            Boolean(env.GOOGLE_CLIENT_ID) && Boolean(env.GOOGLE_CLIENT_SECRET) && urls.length > 0
-          )
-        })(),
+        googleHasRedirectConfig: hasRedirectConfig({
+          urls: env.OAUTH_GOOGLE_CALLBACK_URLS,
+          singleUrl: env.OAUTH_GOOGLE_CALLBACK_URL,
+          clientId: env.GOOGLE_CLIENT_ID,
+          clientSecret: env.GOOGLE_CLIENT_SECRET,
+        }),
         facebook:
           Boolean(env.FACEBOOK_CLIENT_ID) &&
           Boolean(env.FACEBOOK_CLIENT_SECRET) &&
-          Boolean(env.OAUTH_FACEBOOK_CALLBACK_URL),
+          getOAuthAllowedCallbackUrls({
+            urls: env.OAUTH_FACEBOOK_CALLBACK_URLS,
+            singleUrl: env.OAUTH_FACEBOOK_CALLBACK_URL,
+          }).length > 0,
+        facebookHasRedirectConfig: hasRedirectConfig({
+          urls: env.OAUTH_FACEBOOK_CALLBACK_URLS,
+          singleUrl: env.OAUTH_FACEBOOK_CALLBACK_URL,
+          clientId: env.FACEBOOK_CLIENT_ID,
+          clientSecret: env.FACEBOOK_CLIENT_SECRET,
+        }),
         twitter:
           Boolean(env.TWITTER_CLIENT_ID) &&
           Boolean(env.TWITTER_CLIENT_SECRET) &&
-          Boolean(env.OAUTH_TWITTER_CALLBACK_URL),
+          getOAuthAllowedCallbackUrls({
+            urls: env.OAUTH_TWITTER_CALLBACK_URLS,
+            singleUrl: env.OAUTH_TWITTER_CALLBACK_URL,
+          }).length > 0,
+        twitterHasRedirectConfig: hasRedirectConfig({
+          urls: env.OAUTH_TWITTER_CALLBACK_URLS,
+          singleUrl: env.OAUTH_TWITTER_CALLBACK_URL,
+          clientId: env.TWITTER_CLIENT_ID,
+          clientSecret: env.TWITTER_CLIENT_SECRET,
+        }),
       }),
   )
 }

--- a/apps/fastify/src/routes/auth/oauth/twitter/authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/twitter/authorize-url.ts
@@ -48,13 +48,14 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
     },
     async (request, reply) => {
       const twitterClientId = env.TWITTER_CLIENT_ID
+      const twitterClientSecret = env.TWITTER_CLIENT_SECRET
       const allowedUrls = getOAuthAllowedCallbackUrls({
         urls: env.OAUTH_TWITTER_CALLBACK_URLS,
         singleUrl: env.OAUTH_TWITTER_CALLBACK_URL,
       })
       const resolved = resolveOAuthCallbackUrl({
         allowedUrls,
-        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+        requestedRedirectUri: request.query.redirect_uri,
       })
       if (!resolved.ok)
         return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
@@ -65,7 +66,7 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
               ? 'Twitter OAuth is not configured'
               : 'redirect_uri must be one of the configured callback URLs',
         })
-      if (!twitterClientId)
+      if (!twitterClientId || !twitterClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Twitter OAuth is not configured',

--- a/apps/fastify/src/routes/auth/oauth/twitter/authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/twitter/authorize-url.ts
@@ -6,10 +6,18 @@ import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
 const AuthorizeUrlResponseSchema = Type.Object({
   redirectUrl: Type.String(),
+})
+
+const AuthorizeUrlQuerystringSchema = Type.Object({
+  redirect_uri: Type.Optional(Type.String()),
 })
 
 function generateCodeVerifier(): string {
@@ -30,20 +38,39 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         summary: 'Twitter OAuth authorize URL',
         tags: ['auth'],
         security: [],
+        querystring: AuthorizeUrlQuerystringSchema,
         response: {
           200: AuthorizeUrlResponseSchema,
+          400: ErrorResponseSchema,
           503: ErrorResponseSchema,
         },
       },
     },
-    async (_request, reply) => {
+    async (request, reply) => {
       const twitterClientId = env.TWITTER_CLIENT_ID
-      const oauthTwitterCallbackUrl = env.OAUTH_TWITTER_CALLBACK_URL
-      if (!twitterClientId || !oauthTwitterCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_TWITTER_CALLBACK_URLS,
+        singleUrl: env.OAUTH_TWITTER_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'Twitter OAuth is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!twitterClientId)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Twitter OAuth is not configured',
         })
+      const { redirectUri } = resolved
 
       const state = randomUUID() + randomUUID().replace(/-/g, '')
       const stateHash = hashToken(state)
@@ -57,13 +84,13 @@ const oauthAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         type: 'oauth_state',
         identifier: stateHash,
         value: stateHash,
+        meta: { redirectUri, codeVerifier },
         expiresAt,
-        meta: { codeVerifier },
       })
 
       const redirectUrl = new URL('https://x.com/i/oauth2/authorize')
       redirectUrl.searchParams.set('client_id', twitterClientId)
-      redirectUrl.searchParams.set('redirect_uri', oauthTwitterCallbackUrl)
+      redirectUrl.searchParams.set('redirect_uri', redirectUri)
       redirectUrl.searchParams.set('scope', 'tweet.read users.read offline.access')
       redirectUrl.searchParams.set('code_challenge', codeChallenge)
       redirectUrl.searchParams.set('code_challenge_method', 'S256')

--- a/apps/fastify/src/routes/auth/oauth/twitter/exchange.ts
+++ b/apps/fastify/src/routes/auth/oauth/twitter/exchange.ts
@@ -6,6 +6,7 @@ import { isUniqueViolation } from '../../../../lib/db-errors.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
 import { validateAndConsumeOAuthState } from '../../../../lib/oauth-exchange-state.js'
+import { getOAuthAllowedCallbackUrls, type OAuthStateMeta } from '../../../../lib/oauth-shared.js'
 import {
   fetchTwitterOAuthData,
   OAuthUpstreamError,
@@ -52,8 +53,12 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
     async (request, reply) => {
       const twitterClientId = env.TWITTER_CLIENT_ID
       const twitterClientSecret = env.TWITTER_CLIENT_SECRET
-      const oauthTwitterCallbackUrl = env.OAUTH_TWITTER_CALLBACK_URL
-      if (!twitterClientId || !twitterClientSecret || !oauthTwitterCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_TWITTER_CALLBACK_URLS,
+        singleUrl: env.OAUTH_TWITTER_CALLBACK_URL,
+      })
+      const defaultUrl = allowedUrls[0]
+      if (!twitterClientId || !twitterClientSecret || !defaultUrl)
         return reply.code(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Twitter OAuth is not configured',
@@ -75,7 +80,14 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
       })
       if (!validated.ok) return
       const { isLinkMode, linkUserId, stateRecord } = validated
-      const codeVerifier = stateRecord.meta?.codeVerifier
+      const meta = stateRecord.meta as OAuthStateMeta | undefined
+      const redirectUri = meta?.redirectUri ?? defaultUrl
+      if (!allowedUrls.includes(redirectUri))
+        return reply.code(401).send({
+          code: 'INVALID_STATE',
+          message: 'Invalid or tampered redirect URI',
+        })
+      const codeVerifier = meta?.codeVerifier
       if (!codeVerifier)
         return reply.code(401).send({
           code: 'INVALID_STATE',
@@ -89,7 +101,7 @@ const oauthExchangeRoute: FastifyPluginAsync = async fastify => {
         const oauthData = await fetchTwitterOAuthData({
           code,
           codeVerifier,
-          oauthTwitterCallbackUrl,
+          redirectUri,
           twitterClientId,
           twitterClientSecret,
         })

--- a/apps/fastify/src/routes/auth/oauth/twitter/link-authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/twitter/link-authorize-url.ts
@@ -7,6 +7,10 @@ import { getDb } from '../../../../db/index.js'
 import { verification } from '../../../../db/schema/index.js'
 import { env } from '../../../../lib/env.js'
 import { hashToken } from '../../../../lib/jwt.js'
+import {
+  getOAuthAllowedCallbackUrls,
+  resolveOAuthCallbackUrl,
+} from '../../../../lib/oauth-shared.js'
 import { ErrorResponseSchema } from '../../../schemas.js'
 
 const linkAuthorizeUrlPerUserPerHour = 10
@@ -23,6 +27,10 @@ const AuthorizeUrlResponseSchema = Type.Object({
   redirectUrl: Type.String(),
 })
 
+const LinkAuthorizeUrlQuerystringSchema = Type.Object({
+  redirect_uri: Type.Optional(Type.String()),
+})
+
 const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
   fastify.withTypeProvider<TypeBoxTypeProvider>().get(
     '/link-authorize-url',
@@ -33,9 +41,11 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         summary: 'Twitter OAuth link authorize URL',
         tags: ['auth'],
         security: [{ bearerAuth: [] }],
+        querystring: LinkAuthorizeUrlQuerystringSchema,
         response: {
           200: AuthorizeUrlResponseSchema,
           401: ErrorResponseSchema,
+          400: ErrorResponseSchema,
           429: ErrorResponseSchema,
           503: ErrorResponseSchema,
         },
@@ -49,12 +59,29 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         })
 
       const twitterClientId = env.TWITTER_CLIENT_ID
-      const oauthTwitterCallbackUrl = env.OAUTH_TWITTER_CALLBACK_URL
-      if (!twitterClientId || !oauthTwitterCallbackUrl)
+      const allowedUrls = getOAuthAllowedCallbackUrls({
+        urls: env.OAUTH_TWITTER_CALLBACK_URLS,
+        singleUrl: env.OAUTH_TWITTER_CALLBACK_URL,
+      })
+      const resolved = resolveOAuthCallbackUrl({
+        allowedUrls,
+        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+      })
+      if (!resolved.ok)
+        return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
+          code:
+            resolved.error === 'NOT_CONFIGURED' ? 'OAUTH_NOT_CONFIGURED' : 'INVALID_REDIRECT_URI',
+          message:
+            resolved.error === 'NOT_CONFIGURED'
+              ? 'Twitter OAuth is not configured'
+              : 'redirect_uri must be one of the configured callback URLs',
+        })
+      if (!twitterClientId)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Twitter OAuth is not configured',
         })
+      const { redirectUri } = resolved
 
       const userId = request.session.user.id
       const db = await getDb()
@@ -86,13 +113,13 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         type: 'oauth_link_state',
         identifier: `link:${userId}`,
         value: stateHash,
-        meta: { userId, codeVerifier },
+        meta: { userId, codeVerifier, redirectUri },
         expiresAt,
       })
 
       const redirectUrl = new URL('https://x.com/i/oauth2/authorize')
       redirectUrl.searchParams.set('client_id', twitterClientId)
-      redirectUrl.searchParams.set('redirect_uri', oauthTwitterCallbackUrl)
+      redirectUrl.searchParams.set('redirect_uri', redirectUri)
       redirectUrl.searchParams.set('scope', 'tweet.read users.read offline.access')
       redirectUrl.searchParams.set('code_challenge', codeChallenge)
       redirectUrl.searchParams.set('code_challenge_method', 'S256')

--- a/apps/fastify/src/routes/auth/oauth/twitter/link-authorize-url.ts
+++ b/apps/fastify/src/routes/auth/oauth/twitter/link-authorize-url.ts
@@ -59,13 +59,14 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
         })
 
       const twitterClientId = env.TWITTER_CLIENT_ID
+      const twitterClientSecret = env.TWITTER_CLIENT_SECRET
       const allowedUrls = getOAuthAllowedCallbackUrls({
         urls: env.OAUTH_TWITTER_CALLBACK_URLS,
         singleUrl: env.OAUTH_TWITTER_CALLBACK_URL,
       })
       const resolved = resolveOAuthCallbackUrl({
         allowedUrls,
-        requestedRedirectUri: (request.query as { redirect_uri?: string })?.redirect_uri,
+        requestedRedirectUri: request.query.redirect_uri,
       })
       if (!resolved.ok)
         return reply.status(resolved.error === 'NOT_CONFIGURED' ? 503 : 400).send({
@@ -76,7 +77,7 @@ const oauthLinkAuthorizeUrlRoute: FastifyPluginAsync = async fastify => {
               ? 'Twitter OAuth is not configured'
               : 'redirect_uri must be one of the configured callback URLs',
         })
-      if (!twitterClientId)
+      if (!twitterClientId || !twitterClientSecret)
         return reply.status(503).send({
           code: 'OAUTH_NOT_CONFIGURED',
           message: 'Twitter OAuth is not configured',

--- a/apps/next/app/(dashboard)/settings/(profile)/linked-accounts-section.tsx
+++ b/apps/next/app/(dashboard)/settings/(profile)/linked-accounts-section.tsx
@@ -28,7 +28,7 @@ export function LinkedAccountsSection() {
   const { data } = useUser()
   const {
     github: githubEnabled,
-    googleRedirect,
+    googleHasRedirectConfig: googleEnabled,
     facebook: facebookEnabled,
     twitter: twitterEnabled,
   } = useOAuthProviders()
@@ -98,7 +98,7 @@ export function LinkedAccountsSection() {
                   label={label}
                   providersEnabled={{
                     github: githubEnabled,
-                    google: googleRedirect,
+                    google: googleEnabled,
                     facebook: facebookEnabled,
                     twitter: twitterEnabled,
                   }}

--- a/apps/next/app/auth/login/login-actions.tsx
+++ b/apps/next/app/auth/login/login-actions.tsx
@@ -28,6 +28,8 @@ type OAuthButtonsProps = {
   onGoogleClick: () => void
   isGithubConfigured: boolean
   isGoogleConfigured: boolean
+  isGoogleRedirectConfigured: boolean
+  isGoogleReady: boolean
   isFacebookConfigured: boolean
   isTwitterConfigured: boolean
   isOAuthPending: boolean
@@ -44,6 +46,8 @@ function OAuthButtons({
   onGoogleClick,
   isGithubConfigured,
   isGoogleConfigured,
+  isGoogleRedirectConfigured,
+  isGoogleReady,
   isFacebookConfigured,
   isTwitterConfigured,
   isOAuthPending,
@@ -84,7 +88,9 @@ function OAuthButtons({
       </button>
       <button
         type="button"
-        disabled={anyPending || !isGoogleConfigured}
+        disabled={
+          anyPending || !isGoogleConfigured || (!isGoogleRedirectConfigured && !isGoogleReady)
+        }
         onClick={() => {
           setLastAuthMethod('oauth')
           onGoogleClick()
@@ -239,6 +245,8 @@ export function LoginActions({ initialError }: LoginActionsProps): React.JSX.Ele
             onGoogleClick={handleGoogleClick}
             isGithubConfigured={isGithubConfigured}
             isGoogleConfigured={isGoogleConfigured}
+            isGoogleRedirectConfigured={isGoogleRedirectConfigured}
+            isGoogleReady={isGoogleReady}
             isFacebookConfigured={isFacebookConfigured}
             isTwitterConfigured={isTwitterConfigured}
             isOAuthPending={isOAuthPending}

--- a/apps/next/app/auth/login/login-actions.tsx
+++ b/apps/next/app/auth/login/login-actions.tsx
@@ -152,7 +152,7 @@ export function LoginActions({ initialError }: LoginActionsProps): React.JSX.Ele
   const {
     github: isGithubConfigured,
     google: isGoogleConfigured,
-    googleRedirect: isGoogleRedirectConfigured,
+    googleHasRedirectConfig: isGoogleRedirectConfigured,
     facebook: isFacebookConfigured,
     twitter: isTwitterConfigured,
   } = useOAuthProviders()

--- a/packages/core/src/gen/types.gen.ts
+++ b/packages/core/src/gen/types.gen.ts
@@ -985,10 +985,13 @@ export type OauthProvidersResponses = {
      */
     200: {
         github: boolean;
+        githubHasRedirectConfig: boolean;
         google: boolean;
-        googleRedirect: boolean;
+        googleHasRedirectConfig: boolean;
         facebook: boolean;
+        facebookHasRedirectConfig: boolean;
         twitter: boolean;
+        twitterHasRedirectConfig: boolean;
     };
 };
 
@@ -997,11 +1000,20 @@ export type OauthProvidersResponse = OauthProvidersResponses[keyof OauthProvider
 export type OauthFacebookAuthorizeUrlData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        redirect_uri?: string;
+    };
     url: '/auth/oauth/facebook/authorize-url';
 };
 
 export type OauthFacebookAuthorizeUrlErrors = {
+    /**
+     * Default Response
+     */
+    400: {
+        code: string;
+        message: string;
+    };
     /**
      * Default Response
      */
@@ -1097,11 +1109,20 @@ export type OauthFacebookExchangeResponse = OauthFacebookExchangeResponses[keyof
 export type OauthFacebookLinkAuthorizeUrlData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        redirect_uri?: string;
+    };
     url: '/auth/oauth/facebook/link-authorize-url';
 };
 
 export type OauthFacebookLinkAuthorizeUrlErrors = {
+    /**
+     * Default Response
+     */
+    400: {
+        code: string;
+        message: string;
+    };
     /**
      * Default Response
      */
@@ -1141,11 +1162,20 @@ export type OauthFacebookLinkAuthorizeUrlResponse = OauthFacebookLinkAuthorizeUr
 export type OauthGithubAuthorizeUrlData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        redirect_uri?: string;
+    };
     url: '/auth/oauth/github/authorize-url';
 };
 
 export type OauthGithubAuthorizeUrlErrors = {
+    /**
+     * Default Response
+     */
+    400: {
+        code: string;
+        message: string;
+    };
     /**
      * Default Response
      */
@@ -1171,11 +1201,20 @@ export type OauthGithubAuthorizeUrlResponse = OauthGithubAuthorizeUrlResponses[k
 export type OauthGithubAuthorizeData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        redirect_uri?: string;
+    };
     url: '/auth/oauth/github/authorize';
 };
 
 export type OauthGithubAuthorizeErrors = {
+    /**
+     * Default Response
+     */
+    400: {
+        code: string;
+        message: string;
+    };
     /**
      * Default Response
      */
@@ -1253,11 +1292,20 @@ export type OauthGithubExchangeResponse = OauthGithubExchangeResponses[keyof Oau
 export type OauthGithubLinkAuthorizeUrlData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        redirect_uri?: string;
+    };
     url: '/auth/oauth/github/link-authorize-url';
 };
 
 export type OauthGithubLinkAuthorizeUrlErrors = {
+    /**
+     * Default Response
+     */
+    400: {
+        code: string;
+        message: string;
+    };
     /**
      * Default Response
      */
@@ -1506,11 +1554,20 @@ export type OauthGoogleVerifyIdTokenResponse = OauthGoogleVerifyIdTokenResponses
 export type OauthTwitterAuthorizeUrlData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        redirect_uri?: string;
+    };
     url: '/auth/oauth/twitter/authorize-url';
 };
 
 export type OauthTwitterAuthorizeUrlErrors = {
+    /**
+     * Default Response
+     */
+    400: {
+        code: string;
+        message: string;
+    };
     /**
      * Default Response
      */
@@ -1613,11 +1670,20 @@ export type OauthTwitterExchangeResponse = OauthTwitterExchangeResponses[keyof O
 export type OauthTwitterLinkAuthorizeUrlData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        redirect_uri?: string;
+    };
     url: '/auth/oauth/twitter/link-authorize-url';
 };
 
 export type OauthTwitterLinkAuthorizeUrlErrors = {
+    /**
+     * Default Response
+     */
+    400: {
+        code: string;
+        message: string;
+    };
     /**
      * Default Response
      */

--- a/packages/react/src/hooks/use-oauth-link.ts
+++ b/packages/react/src/hooks/use-oauth-link.ts
@@ -12,21 +12,20 @@ export function useOAuthLink(provider: OAuthLinkProvider, redirectUri?: string) 
   return useMutation({
     mutationFn: async () => {
       const linkAuthorizeUrl = {
-        github: () => client.auth.oauth.github.linkAuthorizeUrl({ throwOnError: true }),
-        google: () =>
-          client.auth.oauth.google.linkAuthorizeUrl({
-            throwOnError: true,
-            ...(redirectUri
-              ? {
-                  // biome-ignore lint/style/useNamingConvention: OAuth API expects redirect_uri
-                  query: { redirect_uri: redirectUri },
-                }
-              : {}),
-          }),
-        facebook: () => client.auth.oauth.facebook.linkAuthorizeUrl({ throwOnError: true }),
-        twitter: () => client.auth.oauth.twitter.linkAuthorizeUrl({ throwOnError: true }),
+        github: client.auth.oauth.github.linkAuthorizeUrl,
+        google: client.auth.oauth.google.linkAuthorizeUrl,
+        facebook: client.auth.oauth.facebook.linkAuthorizeUrl,
+        twitter: client.auth.oauth.twitter.linkAuthorizeUrl,
       }[provider]
-      const data = await linkAuthorizeUrl()
+      const data = await linkAuthorizeUrl({
+        throwOnError: true,
+        ...(redirectUri
+          ? {
+              // biome-ignore lint/style/useNamingConvention: OAuth API expects redirect_uri
+              query: { redirect_uri: redirectUri },
+            }
+          : {}),
+      })
       const url = data?.redirectUrl
       if (typeof url !== 'string' || !url.trim())
         throw new Error(`OAuth redirectUrl missing or invalid for provider: ${provider}`)

--- a/packages/react/src/hooks/use-oauth-login.ts
+++ b/packages/react/src/hooks/use-oauth-login.ts
@@ -37,14 +37,20 @@ export function useOAuthLogin(
     mutationFn: async input => {
       const provider = typeof input === 'string' ? input : input.provider
       const redirectUri = typeof input === 'object' ? input.redirectUri : undefined
+      if (redirectUri !== undefined && redirectUri.trim() === '')
+        throw new Error('redirectUri cannot be blank')
       const authorizeUrl = {
-        github: client.auth.oauth.github.authorizeUrl,
-        google: client.auth.oauth.google.authorizeUrl,
-        facebook: client.auth.oauth.facebook.authorizeUrl,
-        twitter: client.auth.oauth.twitter.authorizeUrl,
+        github: (opts?: Parameters<typeof client.auth.oauth.github.authorizeUrl>[0]) =>
+          client.auth.oauth.github.authorizeUrl(opts),
+        google: (opts?: Parameters<typeof client.auth.oauth.google.authorizeUrl>[0]) =>
+          client.auth.oauth.google.authorizeUrl(opts),
+        facebook: (opts?: Parameters<typeof client.auth.oauth.facebook.authorizeUrl>[0]) =>
+          client.auth.oauth.facebook.authorizeUrl(opts),
+        twitter: (opts?: Parameters<typeof client.auth.oauth.twitter.authorizeUrl>[0]) =>
+          client.auth.oauth.twitter.authorizeUrl(opts),
       } as const
       const data = await authorizeUrl[provider](
-        redirectUri
+        redirectUri !== undefined
           ? {
               query: {
                 // biome-ignore lint/style/useNamingConvention: OAuth API expects redirect_uri

--- a/packages/react/src/hooks/use-oauth-login.ts
+++ b/packages/react/src/hooks/use-oauth-login.ts
@@ -37,22 +37,22 @@ export function useOAuthLogin(
     mutationFn: async input => {
       const provider = typeof input === 'string' ? input : input.provider
       const redirectUri = typeof input === 'object' ? input.redirectUri : undefined
-      const data =
-        provider === 'google' && redirectUri
-          ? await client.auth.oauth.google.authorizeUrl({
+      const authorizeUrl = {
+        github: client.auth.oauth.github.authorizeUrl,
+        google: client.auth.oauth.google.authorizeUrl,
+        facebook: client.auth.oauth.facebook.authorizeUrl,
+        twitter: client.auth.oauth.twitter.authorizeUrl,
+      } as const
+      const data = await authorizeUrl[provider](
+        redirectUri
+          ? {
               query: {
                 // biome-ignore lint/style/useNamingConvention: OAuth API expects redirect_uri
                 redirect_uri: redirectUri,
               },
-            })
-          : await (
-              {
-                github: client.auth.oauth.github.authorizeUrl,
-                google: client.auth.oauth.google.authorizeUrl,
-                facebook: client.auth.oauth.facebook.authorizeUrl,
-                twitter: client.auth.oauth.twitter.authorizeUrl,
-              } as const
-            )[provider]()
+            }
+          : undefined,
+      )
       const url = data?.redirectUrl
       if (typeof url !== 'string' || !url.trim())
         throw new Error(`OAuth redirectUrl missing or invalid for provider: ${provider}`)

--- a/packages/react/src/hooks/use-oauth-providers.ts
+++ b/packages/react/src/hooks/use-oauth-providers.ts
@@ -14,10 +14,13 @@ export function useOAuthProviders() {
   })
   return {
     github: data?.github ?? false,
+    githubHasRedirectConfig: data?.githubHasRedirectConfig ?? false,
     google: data?.google ?? false,
-    googleRedirect: data?.googleRedirect ?? false,
+    googleHasRedirectConfig: data?.googleHasRedirectConfig ?? false,
     facebook: data?.facebook ?? false,
+    facebookHasRedirectConfig: data?.facebookHasRedirectConfig ?? false,
     twitter: data?.twitter ?? false,
+    twitterHasRedirectConfig: data?.twitterHasRedirectConfig ?? false,
     isPending,
     isError,
     error,


### PR DESCRIPTION
- Add oauth-shared.ts with OAuthStateMeta, resolveOAuthCallbackUrl, getOAuthAllowedCallbackUrls
- Add OAUTH_*_CALLBACK_URLS env for GitHub, Facebook, Twitter (backward compat with single URL)
- Refactor Google to use shared helper
- Implement redirect_uri support for GitHub, Facebook, Twitter (authorize-url, link-authorize-url, exchange)
- Update GitHub legacy /authorize to reuse shared flow
- Update oauth-twitter to accept dynamic redirectUri
- Normalize providers endpoint: googleRedirect -> googleHasRedirectConfig, add *HasRedirectConfig for all
- Simplify useOAuthLogin and useOAuthLink to provider-agnostic logic
- Update docs, .env-sample with OAUTH_*_CALLBACK_URLS examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth supports multiple callback URLs per provider and a standardized optional redirect_uri across GitHub, Google, Facebook, and Twitter; UI now surfaces per-provider redirect-config flags.
* **Bug Fixes**
  * Stricter redirect_uri validation with clearer error responses for misconfiguration, invalid redirects, and tampered state.
* **Documentation**
  * Updated OAuth docs with unified guidance: callback URL lists, exact-match rules, redirect_uri usage, and account-linking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->