### PR TITLE
feat(cli): add cli package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Fastify • OpenAPI • Next.js • Expo — one stack, multiple platforms.
 ## Packages
 
 - **[@repo/core](packages/core/README.md)** — Runtime-agnostic API client and types generated from OpenAPI specs
+- **[@repo/cli](packages/cli/README.md)** — TypeScript CLI for API (API key auth; ideal for agentic integrations)
 - **[@repo/react](packages/react/README.md)** — React Query hooks for `@repo/core` API functions
 - **[@repo/ui](packages/ui/README.md)** — Shared UI component library (Shadcn/ui, Tailwind)
 - **[@repo/utils](packages/utils/README.md)** — Shared utilities (async, data, debug, error, logger, web3)

--- a/apps/docu/content/docs/development/cli.mdx
+++ b/apps/docu/content/docs/development/cli.mdx
@@ -1,0 +1,44 @@
+---
+title: "CLI Package"
+description: "TypeScript CLI to interact with the Basilic API via API key. Ideal for agentic integrations."
+---
+
+The `@repo/cli` package provides a command-line interface to the Basilic Fastify API. It uses `@repo/core` for all requests and supports only API key auth. Auth endpoints (magic link, OAuth, passkey, etc.) are excluded.
+
+## Auth
+
+1. Env var: `API_KEY` or `BASILIC_API_KEY`
+2. Config file: `~/.config/basilic/config.json`
+3. Interactive prompt (saves to config)
+
+```bash
+basilic config set-api-key bask_xxx_yyy
+```
+
+## Commands
+
+Commands mirror core API nesting: `health-check`, `account apikeys create`, `account apikeys list`, `ai chat`, etc. Use `--help` for OpenAPI-derived descriptions.
+
+```bash
+basilic health-check
+basilic account apikeys list
+basilic ai chat --body '{"messages":[{"role":"user","content":"Hello"}]}'
+```
+
+## Local testing
+
+1. Start API: `pnpm dev`
+2. Create API key via dashboard or `POST /account/apikeys/` with JWT
+3. Run: `API_KEY=bask_xxx node packages/cli/dist/cli.js health-check`
+
+See [packages/cli/README.md](https://github.com/your-org/basilic/blob/main/packages/cli/README.md) for full instructions.
+
+## Agentic integrations
+
+The CLI is suited for AI agents (OpenClaw, Cursor Composer, etc.) as a simpler alternative to MCP:
+
+- Standard stdout/JSON
+- No server setup
+- Easy to wrap in scripts: `result=$(basilic ai chat --body '...')`
+
+Agents can shell out to the CLI and parse JSON output without running an MCP server.

--- a/apps/docu/content/docs/development/cli.mdx
+++ b/apps/docu/content/docs/development/cli.mdx
@@ -31,7 +31,7 @@ basilic ai chat --body '{"messages":[{"role":"user","content":"Hello"}]}'
 2. Create API key via dashboard or `POST /account/apikeys/` with JWT
 3. Run: `API_KEY=bask_xxx node packages/cli/dist/cli.js health-check`
 
-See [packages/cli/README.md](https://github.com/your-org/basilic/blob/main/packages/cli/README.md) for full instructions.
+See [packages/cli/README.md](https://github.com/blockmatic/basilic/blob/main/packages/cli/README.md) for full instructions.
 
 ## Agentic integrations
 

--- a/apps/docu/content/docs/development/packages.mdx
+++ b/apps/docu/content/docs/development/packages.mdx
@@ -37,6 +37,7 @@ Examples:
 | Package | What it is | Entrypoints |
 | --- | --- | --- |
 | `@repo/core` | Generated OpenAPI client + types | `@repo/core` |
+| `@repo/cli` | CLI for Basilic API (API key only) | `basilic` bin |
 | `@repo/react` | React Query hooks + React utilities | `@repo/react` |
 | `@repo/utils` | Cross-runtime utilities | `@repo/utils/*` (prefer subpaths) |
 | `@repo/ui` | Shared shadcn/ui components | `@repo/ui/components/*`, `@repo/ui/lib/*`, `@repo/ui/radix` |

--- a/biome.json
+++ b/biome.json
@@ -147,7 +147,7 @@
       }
     },
     {
-      "includes": ["**/packages/cli/**"],
+      "includes": ["**/packages/cli/src/cli.ts", "**/packages/cli/src/gen/**"],
       "linter": {
         "rules": {
           "suspicious": { "noConsole": "off" },

--- a/biome.json
+++ b/biome.json
@@ -147,6 +147,15 @@
       }
     },
     {
+      "includes": ["**/packages/cli/**"],
+      "linter": {
+        "rules": {
+          "suspicious": { "noConsole": "off" },
+          "style": { "noNonNullAssertion": "off" }
+        }
+      }
+    },
+    {
       "includes": [
         "**/mdx-components.tsx",
         "**/lib/catalogs/**",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,56 @@
+# @repo/cli
+
+TypeScript CLI to interact with the Basilic Fastify API via `@repo/core`. API key auth only; auth endpoints excluded. Ideal for agentic integrations (e.g. OpenClaw) as a simpler alternative to MCP.
+
+## Usage
+
+```bash
+# Install
+pnpm add -g @repo/cli
+
+# Or run from monorepo
+pnpm --filter @repo/cli build
+node packages/cli/dist/cli.js --help
+```
+
+## Auth
+
+Requires an API key. Resolved in order:
+
+1. `API_KEY` or `BASILIC_API_KEY` env var
+2. Config file (`~/.config/basilic/config.json` or `XDG_CONFIG_HOME/basilic/config.json`)
+3. Interactive prompt (saves to config)
+
+```bash
+# Set via env
+export API_KEY=bask_xxx_yyy
+
+# Or save to config
+basilic config set-api-key bask_xxx_yyy
+```
+
+## Commands
+
+Commands mirror the core API nesting (excluding auth endpoints): `health-check`, `account apikeys create`, `account apikeys list`, `ai chat`, etc. Use `--help` on any command for OpenAPI-derived descriptions.
+
+## Local testing
+
+1. Start API: `pnpm dev`
+2. Create API key via dashboard or `POST /account/apikeys/` with JWT
+3. Run:
+
+   ```bash
+   API_KEY=bask_xxx node packages/cli/dist/cli.js health-check
+   API_KEY=bask_xxx node packages/cli/dist/cli.js account apikeys list
+   ```
+
+4. Or build and run:
+
+   ```bash
+   pnpm --filter @repo/cli build
+   pnpm --filter @repo/cli exec basilic health-check
+   ```
+
+## Agentic integrations
+
+The CLI is designed for AI agents (OpenClaw, Cursor Composer, etc.) as a lightweight alternative to MCP: standard stdout/JSON, no server setup, easy to wrap in scripts.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,10 +5,6 @@ TypeScript CLI to interact with the Basilic Fastify API via `@repo/core`. API ke
 ## Usage
 
 ```bash
-# Install
-pnpm add -g @repo/cli
-
-# Or run from monorepo
 pnpm --filter @repo/cli build
 node packages/cli/dist/cli.js --help
 ```
@@ -18,7 +14,7 @@ node packages/cli/dist/cli.js --help
 Requires an API key. Resolved in order:
 
 1. `API_KEY` or `BASILIC_API_KEY` env var
-2. Config file (`~/.config/basilic/config.json` or `XDG_CONFIG_HOME/basilic/config.json`)
+2. Config file (`~/.config/basilic/config.json` or `$XDG_CONFIG_HOME/basilic/config.json`)
 3. Interactive prompt (saves to config)
 
 ```bash

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -1,0 +1,24 @@
+import { config } from '@repo/eslint-config/library'
+
+export default [
+  ...config,
+  {
+    ignores: ['**/gen/**', '**/*.gen.ts', '**/*.gen.js'],
+  },
+  {
+    files: ['src/config.ts'],
+    rules: {
+      'no-restricted-properties': 'off',
+      'turbo/no-undeclared-env-vars': 'off',
+    },
+  },
+  {
+    files: ['scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+      },
+    },
+  },
+]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@repo/cli",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "description": "TypeScript CLI to interact with Basilic Fastify API via API key",
+  "bin": {
+    "basilic": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/cli.ts",
+      "import": "./dist/cli.js",
+      "default": "./dist/cli.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "checktypes": "tsgo --noEmit",
+    "generate": "node --import tsx scripts/generate-cli.mjs",
+    "lint:eslint": "eslint . --max-warnings 0",
+    "lint:eslint:fix": "eslint . --fix --max-warnings 0",
+    "lint:biome": "biome check .",
+    "lint:biome:fix": "biome check . --write"
+  },
+  "dependencies": {
+    "@repo/core": "workspace:*",
+    "commander": "^13.1.0"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "tsup": "^8.5.1",
+    "tsx": "^4.21.0"
+  }
+}

--- a/packages/cli/scripts/generate-cli.mjs
+++ b/packages/cli/scripts/generate-cli.mjs
@@ -1,0 +1,137 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptFile = fileURLToPath(import.meta.url)
+const scriptDir = dirname(scriptFile)
+const openapiPath = join(scriptDir, '../../../apps/fastify/openapi/openapi.json')
+const outputDir = join(scriptDir, '../src/gen')
+const outputPath = join(outputDir, 'commands.gen.ts')
+
+// Convert string to camelCase; strip {...} from path params for valid keys
+function toCamelCase(str) {
+  const cleaned = str.replace(/^\{|\}$/g, '')
+  return cleaned.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+}
+
+// camelCase to kebab-case for CLI
+function toKebabCase(str) {
+  return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+}
+
+// Extract action key from operationId (e.g. accountApikeysCreate -> create)
+function toActionKey(operationId) {
+  const match = operationId.match(/[A-Z][a-z]+$/)
+  return match ? match[0].toLowerCase() : operationId
+}
+
+// Build nested object structure from path segments (same as core generate-wrapper)
+function buildNestedObject(obj, segments, operationId) {
+  if (segments.length === 0) return operationId
+
+  const [first, ...rest] = segments
+  const key = toCamelCase(first)
+
+  if (rest.length === 0) {
+    const existing = obj[key]
+    if (typeof existing === 'string')
+      obj[key] = { [toActionKey(existing)]: existing, [toActionKey(operationId)]: operationId }
+    else if (existing && typeof existing === 'object' && !Array.isArray(existing))
+      obj[key][toActionKey(operationId)] = operationId
+    else obj[key] = operationId
+
+    return obj
+  }
+
+  const existing = obj[key]
+  if (typeof existing === 'string') obj[key] = { [toActionKey(existing)]: existing }
+
+  if (!obj[key] || typeof obj[key] === 'string') obj[key] = {}
+
+  buildNestedObject(obj[key], rest, operationId)
+  return obj
+}
+
+// Traverse nested structure and collect { path, operationId } for each leaf
+function collectCommandSpecs(obj, pathPrefix = [], acc = []) {
+  for (const [key, value] of Object.entries(obj)) {
+    const path = [...pathPrefix, key]
+    if (typeof value === 'string') acc.push({ path, operationId: value })
+    else collectCommandSpecs(value, path, acc)
+  }
+  return acc
+}
+
+// Extract path and body params from OpenAPI operation
+function getParams(operation) {
+  const pathParams = []
+  const bodyParams = []
+  const params = operation.parameters ?? []
+  for (const p of params) if (p.in === 'path' && p.name) pathParams.push({ name: p.name })
+
+  const body = operation.requestBody?.content?.['application/json']?.schema
+  if (body?.properties) for (const name of Object.keys(body.properties)) bodyParams.push({ name })
+
+  return { pathParams, bodyParams }
+}
+
+// Read OpenAPI spec
+const openapiSpec = JSON.parse(readFileSync(openapiPath, 'utf-8'))
+const paths = openapiSpec.paths || {}
+const nestedStructure = {}
+
+for (const [path, methods] of Object.entries(paths)) {
+  if (path.startsWith('/auth')) continue
+  if (typeof methods !== 'object' || methods === null) continue
+
+  for (const [method, operation] of Object.entries(methods)) {
+    if (!['get', 'post', 'put', 'patch', 'delete', 'options', 'head'].includes(method)) continue
+    if (typeof operation !== 'object' || operation === null) continue
+
+    let operationId = operation.operationId
+    if (!operationId) operationId = method.toLowerCase()
+
+    const pathSegments = path.split('/').filter(Boolean)
+    if (path === '/') continue
+
+    if (pathSegments.length === 1) {
+      nestedStructure[operationId] = operationId
+      continue
+    }
+
+    buildNestedObject(nestedStructure, pathSegments, operationId)
+  }
+}
+
+const rawSpecs = collectCommandSpecs(nestedStructure)
+const operationMeta = {}
+const commandSpecs = []
+
+for (const { path, operationId } of rawSpecs) {
+  let op
+  for (const [p, methods] of Object.entries(paths)) {
+    if (p.startsWith('/auth')) continue
+    for (const [, operation] of Object.entries(methods ?? {}))
+      if (operation?.operationId === operationId) {
+        op = operation
+        break
+      }
+  }
+  const { pathParams, bodyParams } = op ? getParams(op) : { pathParams: [], bodyParams: [] }
+  const summary = op?.summary ?? operationId
+  const description = op?.description ?? summary
+
+  operationMeta[operationId] = { summary, description, pathParams, bodyParams }
+  const cliPath = path.map(s => (s.includes('-') ? s : toKebabCase(s)))
+  commandSpecs.push({ path: cliPath, operationId })
+}
+
+const output = `// This file is auto-generated. Do not edit manually.
+
+export const operationMeta = ${JSON.stringify(operationMeta, null, 2)} as const
+
+export const commandSpecs = ${JSON.stringify(commandSpecs, null, 2)} as const
+`
+
+mkdirSync(outputDir, { recursive: true })
+writeFileSync(outputPath, output, 'utf-8')

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createInterface } from 'node:readline'
+import { Writable } from 'node:stream'
 import { createClient } from '@repo/core'
 import { Command } from 'commander'
 import { loadConfig, resolveApiKey, resolveBaseUrl, saveConfig } from './config.js'
@@ -8,11 +9,23 @@ import { commandSpecs, operationMeta } from './gen/commands.gen.js'
 import { runCommand } from './run-command.js'
 
 async function promptApiKey(): Promise<string> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout })
-  return new Promise(resolve => {
+  const mutedStdout = new Writable({
+    write(chunk, _encoding, callback) {
+      if (!(mutedStdout as Writable & { muted?: boolean }).muted) process.stdout.write(chunk)
+      callback()
+    },
+  }) as Writable & { muted?: boolean }
+  mutedStdout.muted = true
+  const rl = createInterface({ input: process.stdin, output: mutedStdout, terminal: true })
+  return new Promise((resolve, reject) => {
     rl.question('API key: ', answer => {
       rl.close()
+      mutedStdout.muted = false
       resolve(answer.trim())
+    })
+    rl.once('error', err => {
+      mutedStdout.muted = false
+      reject(err)
     })
   })
 }
@@ -126,8 +139,9 @@ function registerApiCommand(cmd: Command, spec: CommandSpec, meta: OperationMeta
   for (const p of meta.bodyParams) cmd.option(`--${p.name} <value>`, `body.${p.name}`)
   cmd.option('--body <json>', 'raw JSON body (overrides individual body opts)')
   cmd.action(async function (this: Command, ...positionalArgs: unknown[]) {
-    const baseUrl = (this.parent?.opts().baseUrl as string) ?? resolveBaseUrl()
-    const optsFromCmd = (this.opts?.() ?? {}) as Record<string, unknown>
+    const merged = this.optsWithGlobals() as Record<string, unknown>
+    const baseUrl = (merged.baseUrl as string) ?? resolveBaseUrl()
+    const optsFromCmd = merged
     const pathParamValues: Record<string, string> = {}
     meta.pathParams.forEach((p, i) => {
       const val = positionalArgs[i]

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import { createInterface } from 'node:readline'
+import { createClient } from '@repo/core'
+import { Command } from 'commander'
+import { loadConfig, resolveApiKey, resolveBaseUrl, saveConfig } from './config.js'
+import { commandSpecs, operationMeta } from './gen/commands.gen.js'
+import { runCommand } from './run-command.js'
+
+async function promptApiKey(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise(resolve => {
+    rl.question('API key: ', answer => {
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}
+
+async function ensureApiKey(): Promise<string> {
+  const fromEnv = resolveApiKey()
+  if (fromEnv) return fromEnv
+  const fromConfig = loadConfig().apiKey
+  if (fromConfig) return fromConfig
+
+  if (!process.stdin.isTTY) {
+    console.error(
+      'API key required. Set API_KEY or BASILIC_API_KEY env var, or run: basilic config set-api-key',
+    )
+    process.exit(1)
+  }
+
+  const key = await promptApiKey()
+  if (!key) {
+    console.error('API key is required')
+    process.exit(1)
+  }
+  saveConfig({ apiKey: key })
+  return key
+}
+
+function buildOpts(
+  meta: (typeof operationMeta)[keyof typeof operationMeta],
+  cmdOpts: Record<string, unknown>,
+): Record<string, string | undefined> {
+  const opts: Record<string, string | undefined> = {}
+  const rawBody = cmdOpts.body as string | undefined
+  if (rawBody)
+    try {
+      const parsed = JSON.parse(rawBody) as Record<string, unknown>
+      for (const [k, v] of Object.entries(parsed)) if (v !== undefined) opts[k] = String(v)
+      return opts
+    } catch {
+      console.error('Invalid --body JSON')
+      process.exit(1)
+    }
+
+  for (const p of meta.pathParams) opts[p.name] = String(cmdOpts[p.name] ?? '')
+  for (const p of meta.bodyParams) opts[p.name] = String(cmdOpts[p.name] ?? '')
+  return opts
+}
+
+function toKebab(str: string): string {
+  return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+}
+
+const program = new Command()
+
+program
+  .name('basilic')
+  .description('CLI for Basilic API (API key auth only; excludes auth endpoints)')
+  .version('0.0.0')
+  .option('-b, --base-url <url>', 'API base URL', resolveBaseUrl())
+
+const configCmd = program.command('config').description('Config management')
+configCmd
+  .command('set-api-key [key]')
+  .description('Set API key (prompts if omitted)')
+  .action(async (key?: string) => {
+    let value = key
+    if (!value) {
+      if (!process.stdin.isTTY) {
+        console.error('Provide key as argument or set API_KEY env var')
+        process.exit(1)
+      }
+      value = await promptApiKey()
+    }
+    if (!value) {
+      console.error('API key is required')
+      process.exit(1)
+    }
+    saveConfig({ apiKey: value })
+    console.log('API key saved to config')
+  })
+
+configCmd
+  .command('set-base-url <url>')
+  .description('Set default base URL')
+  .action((url: string) => {
+    saveConfig({ baseUrl: url })
+    console.log('Base URL saved to config')
+  })
+
+const commandCache = new Map<string, Command>()
+
+function getOrCreateCommand(parent: Command, pathSegment: string): Command {
+  const fullPath = parent === program ? pathSegment : `${parent.name()} ${pathSegment}`
+  const cached = commandCache.get(fullPath)
+  if (cached) return cached
+
+  const cmd = parent.command(pathSegment)
+  commandCache.set(fullPath, cmd)
+  return cmd
+}
+
+type CommandSpec = (typeof commandSpecs)[number]
+type OperationMeta = (typeof operationMeta)[keyof typeof operationMeta]
+
+function registerApiCommand(cmd: Command, spec: CommandSpec, meta: OperationMeta) {
+  const seg = spec.path[spec.path.length - 1]!
+  cmd.summary(meta.summary).description(meta.description)
+  for (const p of meta.pathParams)
+    if (seg === toKebab(p.name)) cmd.argument(`<${p.name}>`, `${p.name} (path param)`)
+    else cmd.option(`--${p.name} <value>`, `${p.name} (path param)`)
+
+  for (const p of meta.bodyParams) cmd.option(`--${p.name} <value>`, `body.${p.name}`)
+  cmd.option('--body <json>', 'raw JSON body (overrides individual body opts)')
+  cmd.action(async function (this: Command, ...positionalArgs: unknown[]) {
+    const baseUrl = (this.parent?.opts().baseUrl as string) ?? resolveBaseUrl()
+    const optsFromCmd = (this.opts?.() ?? {}) as Record<string, unknown>
+    const pathParamValues: Record<string, string> = {}
+    meta.pathParams.forEach((p, i) => {
+      const val = positionalArgs[i]
+      if (val !== undefined) pathParamValues[p.name] = String(val)
+    })
+    const cmdOpts = { ...optsFromCmd, ...pathParamValues }
+    const apiKey = await ensureApiKey()
+    const client = createClient({ baseUrl, apiKey })
+    const opts = buildOpts(meta, cmdOpts)
+    try {
+      const result = await runCommand({ client, spec, meta, opts })
+      console.log(JSON.stringify(result, null, 2))
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      const body =
+        err && typeof err === 'object' && 'body' in err
+          ? (err as { body: unknown }).body
+          : undefined
+      console.error('Error:', msg)
+      if (body) console.error('Details:', JSON.stringify(body, null, 2))
+      process.exit(1)
+    }
+  })
+}
+
+for (const spec of commandSpecs) {
+  const meta = operationMeta[spec.operationId as keyof typeof operationMeta]
+  let parent: Command = program
+  for (let i = 0; i < spec.path.length; i++) {
+    const seg = spec.path[i]!
+    const cmd = getOrCreateCommand(parent, seg)
+    if (i === spec.path.length - 1) registerApiCommand(cmd, spec, meta)
+    parent = cmd
+  }
+}
+
+program.parse()

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir, platform } from 'node:os'
+import { join } from 'node:path'
+
+export type Config = {
+  apiKey?: string
+  baseUrl?: string
+}
+
+function getConfigDir(): string {
+  const envHome = process.env.XDG_CONFIG_HOME
+  if (envHome) return join(envHome, 'basilic')
+  const home = homedir()
+  return platform() === 'win32'
+    ? join(home, 'AppData', 'Local', 'basilic')
+    : join(home, '.config', 'basilic')
+}
+
+export function getConfigPath(): string {
+  return join(getConfigDir(), 'config.json')
+}
+
+export function loadConfig(): Config {
+  const path = getConfigPath()
+  if (!existsSync(path)) return {}
+  try {
+    const raw = readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    return {
+      apiKey: typeof parsed.apiKey === 'string' ? parsed.apiKey : undefined,
+      baseUrl: typeof parsed.baseUrl === 'string' ? parsed.baseUrl : undefined,
+    }
+  } catch {
+    return {}
+  }
+}
+
+export function saveConfig({ apiKey, baseUrl }: Partial<Config>): void {
+  const path = getConfigPath()
+  const dir = join(path, '..')
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  const current = loadConfig()
+  const next: Config = {
+    ...current,
+    ...(apiKey !== undefined && { apiKey }),
+    ...(baseUrl !== undefined && { baseUrl }),
+  }
+  writeFileSync(path, JSON.stringify(next, null, 2), 'utf-8')
+}
+
+export function resolveApiKey(): string | undefined {
+  return process.env.API_KEY ?? process.env.BASILIC_API_KEY ?? loadConfig().apiKey
+}
+
+export function resolveBaseUrl(): string {
+  return (
+    process.env.BASE_URL ?? process.env.API_URL ?? loadConfig().baseUrl ?? 'http://localhost:3000'
+  )
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -38,14 +38,14 @@ export function loadConfig(): Config {
 export function saveConfig({ apiKey, baseUrl }: Partial<Config>): void {
   const path = getConfigPath()
   const dir = join(path, '..')
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 })
   const current = loadConfig()
   const next: Config = {
     ...current,
     ...(apiKey !== undefined && { apiKey }),
     ...(baseUrl !== undefined && { baseUrl }),
   }
-  writeFileSync(path, JSON.stringify(next, null, 2), 'utf-8')
+  writeFileSync(path, JSON.stringify(next, null, 2), { encoding: 'utf-8', mode: 0o600 })
 }
 
 export function resolveApiKey(): string | undefined {

--- a/packages/cli/src/gen/commands.gen.ts
+++ b/packages/cli/src/gen/commands.gen.ts
@@ -1,0 +1,413 @@
+// This file is auto-generated. Do not edit manually.
+
+export const operationMeta = {
+  "healthCheck": {
+    "summary": "Returns server health status with current ISO datetime",
+    "description": "Health check endpoint",
+    "pathParams": [],
+    "bodyParams": []
+  },
+  "accountApikeysCreate": {
+    "summary": "Create API key",
+    "description": "Create API key (shown once)",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "name"
+      }
+    ]
+  },
+  "accountApikeysList": {
+    "summary": "List API keys",
+    "description": "List API keys for authenticated user",
+    "pathParams": [],
+    "bodyParams": []
+  },
+  "accountApikeysRevoke": {
+    "summary": "Revoke API key",
+    "description": "Revoke API key",
+    "pathParams": [
+      {
+        "name": "id"
+      }
+    ],
+    "bodyParams": []
+  },
+  "accountEmailChangeRequest": {
+    "summary": "Change email request",
+    "description": "Request change of email for authenticated user",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "email"
+      },
+      {
+        "name": "callbackUrl"
+      }
+    ]
+  },
+  "accountEmailChangeVerify": {
+    "summary": "Change email verify",
+    "description": "Verify change email token (6-digit code) and update user email",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "token"
+      },
+      {
+        "name": "email"
+      },
+      {
+        "name": "verificationId"
+      }
+    ]
+  },
+  "accountLinkEmailRequest": {
+    "summary": "Link email request",
+    "description": "Request email to link to authenticated user",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "email"
+      },
+      {
+        "name": "callbackUrl"
+      }
+    ]
+  },
+  "accountLinkEmailVerify": {
+    "summary": "Link email verify",
+    "description": "Verify link email token and update user email",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "token"
+      }
+    ]
+  },
+  "accountLinkOauthUnlink": {
+    "summary": "OAuth unlink",
+    "description": "Unlink OAuth provider from authenticated user",
+    "pathParams": [
+      {
+        "name": "providerId"
+      }
+    ],
+    "bodyParams": []
+  },
+  "accountLinkPasskeyDelete": {
+    "summary": "Remove passkey",
+    "description": "Remove passkey by id",
+    "pathParams": [
+      {
+        "name": "id"
+      }
+    ],
+    "bodyParams": []
+  },
+  "accountLinkPasskeyFinish": {
+    "summary": "Passkey registration finish",
+    "description": "Finish passkey registration, verify and store credential",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "credential"
+      },
+      {
+        "name": "name"
+      }
+    ]
+  },
+  "accountLinkPasskeyStart": {
+    "summary": "Passkey registration start",
+    "description": "Start passkey registration, returns options for startRegistration",
+    "pathParams": [],
+    "bodyParams": []
+  },
+  "accountLinkTotpSetup": {
+    "summary": "TOTP setup",
+    "description": "Start TOTP setup, returns QR and manual key",
+    "pathParams": [],
+    "bodyParams": []
+  },
+  "accountLinkTotpUnlink": {
+    "summary": "TOTP unlink",
+    "description": "Remove TOTP authenticator",
+    "pathParams": [],
+    "bodyParams": []
+  },
+  "accountLinkTotpVerify": {
+    "summary": "TOTP verify",
+    "description": "Verify TOTP code and persist authenticator",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "code"
+      }
+    ]
+  },
+  "accountLinkWalletUnlink": {
+    "summary": "Unlink wallet",
+    "description": "Unlink wallet from authenticated user",
+    "pathParams": [
+      {
+        "name": "id"
+      }
+    ],
+    "bodyParams": []
+  },
+  "accountLinkWalletVerify": {
+    "summary": "Link wallet",
+    "description": "Link wallet to authenticated user",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "chain"
+      },
+      {
+        "name": "message"
+      },
+      {
+        "name": "signature"
+      }
+    ]
+  },
+  "accountPasskeysList": {
+    "summary": "List passkeys",
+    "description": "List passkeys for authenticated user",
+    "pathParams": [],
+    "bodyParams": []
+  },
+  "accountProfileUpdate": {
+    "summary": "Update profile",
+    "description": "Update profile (name, username)",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "name"
+      },
+      {
+        "name": "username"
+      }
+    ]
+  },
+  "chat": {
+    "summary": "Generate AI chat response",
+    "description": "Chat with AI via Anthropic, Open Router, or Ollama. Set ANTHROPIC_API_KEY, OPEN_ROUTER_API_KEY, or OLLAMA_BASE_URL. Default model configurable via AI_DEFAULT_MODEL. Supports streaming and tools.",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "messages"
+      },
+      {
+        "name": "stream"
+      },
+      {
+        "name": "model"
+      },
+      {
+        "name": "temperature"
+      },
+      {
+        "name": "tools"
+      }
+    ]
+  },
+  "generate": {
+    "summary": "Generate text from prompt",
+    "description": "Generate text from a single prompt (CLI, scripts, pipelines). Uses Anthropic, Open Router, or Ollama. Returns SSE (text/event-stream) when streaming.",
+    "pathParams": [],
+    "bodyParams": [
+      {
+        "name": "prompt"
+      },
+      {
+        "name": "stream"
+      },
+      {
+        "name": "model"
+      },
+      {
+        "name": "temperature"
+      }
+    ]
+  }
+} as const
+
+export const commandSpecs = [
+  {
+    "path": [
+      "health-check"
+    ],
+    "operationId": "healthCheck"
+  },
+  {
+    "path": [
+      "account",
+      "apikeys",
+      "create"
+    ],
+    "operationId": "accountApikeysCreate"
+  },
+  {
+    "path": [
+      "account",
+      "apikeys",
+      "list"
+    ],
+    "operationId": "accountApikeysList"
+  },
+  {
+    "path": [
+      "account",
+      "apikeys",
+      "id"
+    ],
+    "operationId": "accountApikeysRevoke"
+  },
+  {
+    "path": [
+      "account",
+      "email",
+      "change",
+      "request"
+    ],
+    "operationId": "accountEmailChangeRequest"
+  },
+  {
+    "path": [
+      "account",
+      "email",
+      "change",
+      "verify"
+    ],
+    "operationId": "accountEmailChangeVerify"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "email",
+      "request"
+    ],
+    "operationId": "accountLinkEmailRequest"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "email",
+      "verify"
+    ],
+    "operationId": "accountLinkEmailVerify"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "oauth",
+      "provider-id"
+    ],
+    "operationId": "accountLinkOauthUnlink"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "passkey",
+      "id"
+    ],
+    "operationId": "accountLinkPasskeyDelete"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "passkey",
+      "finish"
+    ],
+    "operationId": "accountLinkPasskeyFinish"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "passkey",
+      "start"
+    ],
+    "operationId": "accountLinkPasskeyStart"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "totp",
+      "setup"
+    ],
+    "operationId": "accountLinkTotpSetup"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "totp",
+      "unlink"
+    ],
+    "operationId": "accountLinkTotpUnlink"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "totp",
+      "verify"
+    ],
+    "operationId": "accountLinkTotpVerify"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "wallet",
+      "id"
+    ],
+    "operationId": "accountLinkWalletUnlink"
+  },
+  {
+    "path": [
+      "account",
+      "link",
+      "wallet",
+      "verify"
+    ],
+    "operationId": "accountLinkWalletVerify"
+  },
+  {
+    "path": [
+      "account",
+      "passkeys"
+    ],
+    "operationId": "accountPasskeysList"
+  },
+  {
+    "path": [
+      "account",
+      "profile"
+    ],
+    "operationId": "accountProfileUpdate"
+  },
+  {
+    "path": [
+      "ai",
+      "chat"
+    ],
+    "operationId": "chat"
+  },
+  {
+    "path": [
+      "ai",
+      "generate"
+    ],
+    "operationId": "generate"
+  }
+] as const

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -1,0 +1,74 @@
+import type { CoreApiClient } from '@repo/core'
+import type { commandSpecs, operationMeta } from './gen/commands.gen'
+
+type CommandSpec = (typeof commandSpecs)[number]
+type OperationMeta = (typeof operationMeta)[keyof typeof operationMeta]
+
+function toCamelCase(str: string): string {
+  return str.replace(/-([a-z])/g, (_, letter) => (letter as string).toUpperCase())
+}
+
+function getNested(
+  client: object,
+  path: readonly string[],
+): ((opts: object) => Promise<unknown>) | undefined {
+  let obj: unknown = client
+  for (const segment of path) {
+    if (obj === null || obj === undefined || typeof obj !== 'object') return undefined
+    const key = segment.includes('-') ? toCamelCase(segment) : segment
+    obj = (obj as Record<string, unknown>)[key]
+  }
+  return typeof obj === 'function' ? (obj as (opts: object) => Promise<unknown>) : undefined
+}
+
+function buildClientPath(spec: CommandSpec): string[] {
+  return spec.path.map(seg => (seg.includes('-') ? toCamelCase(seg) : seg))
+}
+
+export async function runCommand({
+  client,
+  spec,
+  meta,
+  opts,
+}: {
+  client: CoreApiClient
+  spec: CommandSpec
+  meta: OperationMeta
+  opts: Record<string, string | undefined>
+}): Promise<unknown> {
+  const clientPath = buildClientPath(spec)
+  const fn = getNested(client, clientPath)
+  if (!fn) throw new Error(`Command not found: ${spec.path.join(' ')}`)
+
+  const pathParams: Record<string, string> = {}
+  for (const p of meta.pathParams) {
+    const v = opts[p.name]
+    if (v) pathParams[p.name] = v
+  }
+  const bodyParams: Record<string, unknown> = {}
+  for (const p of meta.bodyParams) {
+    const v = opts[p.name]
+    if (v !== undefined && v !== '')
+      if (p.name === 'messages' && typeof v === 'string')
+        try {
+          bodyParams[p.name] = JSON.parse(v) as unknown
+        } catch {
+          bodyParams[p.name] = [{ role: 'user', content: v }]
+        }
+      else if (p.name === 'stream' && (v === 'true' || v === '1')) bodyParams[p.name] = true
+      else if ((p.name === 'temperature' || p.name === 'model') && v)
+        bodyParams[p.name] = p.name === 'temperature' ? Number.parseFloat(v) : v
+      else if (p.name === 'tools' && typeof v === 'string')
+        try {
+          bodyParams[p.name] = JSON.parse(v) as unknown
+        } catch {
+          bodyParams[p.name] = undefined
+        }
+      else bodyParams[p.name] = v
+  }
+
+  const callOpts: Record<string, unknown> = {}
+  if (Object.keys(pathParams).length > 0) callOpts.path = pathParams
+  if (Object.keys(bodyParams).length > 0) callOpts.body = bodyParams
+  return fn(callOpts)
+}

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -55,14 +55,24 @@ export async function runCommand({
         } catch {
           bodyParams[p.name] = [{ role: 'user', content: v }]
         }
-      else if (p.name === 'stream' && (v === 'true' || v === '1')) bodyParams[p.name] = true
+      else if (p.name === 'stream')
+        if (v === 'true' || v === '1') bodyParams[p.name] = true
+        else if (v === 'false' || v === '0') bodyParams[p.name] = false
+        else throw new Error(`Invalid --stream value: ${v}. Use true, 1, false, or 0`)
       else if ((p.name === 'temperature' || p.name === 'model') && v)
-        bodyParams[p.name] = p.name === 'temperature' ? Number.parseFloat(v) : v
+        if (p.name === 'temperature') {
+          const n = Number.parseFloat(v)
+          if (!Number.isFinite(n))
+            throw new Error(`Invalid --temperature value: ${v}. Must be a finite number`)
+          bodyParams[p.name] = n
+        } else {
+          bodyParams[p.name] = v
+        }
       else if (p.name === 'tools' && typeof v === 'string')
         try {
           bodyParams[p.name] = JSON.parse(v) as unknown
         } catch {
-          bodyParams[p.name] = undefined
+          throw new Error(`Invalid --tools JSON: ${v}`)
         }
       else bodyParams[p.name] = v
   }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  format: ['esm'],
+  target: 'node20',
+  sourcemap: true,
+  clean: true,
+  outDir: 'dist',
+  noExternal: ['@repo/core'],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,7 +353,7 @@ importers:
         version: link:../../packages/utils
       '@sentry/nextjs':
         specifier: ^10.38.0
-        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3))
+        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.2)
       '@solana/wallet-adapter-base':
         specifier: ^0.9.27
         version: 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -407,7 +407,7 @@ importers:
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nuqs:
         specifier: ^2.8.8
-        version: 2.8.8(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.8.8(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -475,6 +475,28 @@ importers:
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
+
+  packages/cli:
+    dependencies:
+      '@repo/core':
+        specifier: workspace:*
+        version: link:../core
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../../tools/eslint
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../tools/typescript
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
   packages/core:
     devDependencies:
@@ -578,7 +600,7 @@ importers:
         version: 10.39.0
       '@sentry/nextjs':
         specifier: ^10.38.0
-        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3))
+        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.2)
       '@sentry/node':
         specifier: ^10.38.0
         version: 10.39.0
@@ -951,7 +973,7 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       nuqs:
         specifier: ^2.8.8
-        version: 2.8.8(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.8.8(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -17305,7 +17327,7 @@ snapshots:
 
   '@sentry/core@10.39.0': {}
 
-  '@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.2(esbuild@0.27.3))':
+  '@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -17317,7 +17339,7 @@ snapshots:
       '@sentry/opentelemetry': 10.39.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
       '@sentry/react': 10.39.0(react@19.2.4)
       '@sentry/vercel-edge': 10.39.0
-      '@sentry/webpack-plugin': 4.9.1(webpack@5.105.2(esbuild@0.27.3))
+      '@sentry/webpack-plugin': 4.9.1(webpack@5.105.2)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -17408,12 +17430,12 @@ snapshots:
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.39.0
 
-  '@sentry/webpack-plugin@4.9.1(webpack@5.105.2(esbuild@0.27.3))':
+  '@sentry/webpack-plugin@4.9.1(webpack@5.105.2)':
     dependencies:
       '@sentry/bundler-plugin-core': 4.9.1
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.105.2(esbuild@0.27.3)
+      webpack: 5.105.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -25379,7 +25401,7 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuqs@2.8.8(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  nuqs@2.8.8(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.4
@@ -27432,15 +27454,13 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.3.17(esbuild@0.27.3)(webpack@5.105.2(esbuild@0.27.3)):
+  terser-webpack-plugin@5.3.17(webpack@5.105.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.105.2(esbuild@0.27.3)
-    optionalDependencies:
-      esbuild: 0.27.3
+      webpack: 5.105.2
 
   terser@5.46.0:
     dependencies:
@@ -28316,7 +28336,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.105.2(esbuild@0.27.3):
+  webpack@5.105.2:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -28340,7 +28360,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.17(esbuild@0.27.3)(webpack@5.105.2(esbuild@0.27.3))
+      terser-webpack-plugin: 5.3.17(webpack@5.105.2)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,16 @@
       "outputs": ["src/gen/**"],
       "env": ["NODE_ENV"]
     },
+    "@repo/cli#generate": {
+      "dependsOn": ["@repo/core#generate"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../apps/fastify/openapi/openapi.json",
+        "scripts/generate-cli.mjs"
+      ],
+      "outputs": ["src/gen/**"],
+      "env": ["NODE_ENV"]
+    },
     "build": {
       "dependsOn": ["^build", "generate"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],


### PR DESCRIPTION
- Add packages/cli with Commander, API key auth, config persistence
- Exclude auth endpoints; mirror core API nesting
- Generate commands from OpenAPI (scripts/generate-cli.mjs)
- Config: API_KEY/BASILIC_API_KEY env or ~/.config/basilic/config.json
- Docs: README, development/cli.mdx, agentic integrations note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new CLI for the Basilic API with API key auth, dynamic commands reflecting API endpoints, and JSON output for scripting/agent use.
* **Documentation**
  * Added user docs and README describing CLI usage, auth methods, commands, local testing, and agentic integration notes.
* **Chores**
  * Added package manifest, build config, generation task, lint overrides, and generation tooling to support the new CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->