### PR TITLE
test(web): cover validated token persistence close-out

### DIFF
--- a/.cursor/rules/frontend/auth.mdc
+++ b/.cursor/rules/frontend/auth.mdc
@@ -28,6 +28,7 @@ alwaysApply: false
 ## Mutations
 
 - Login, profile, passkeys, TOTP, and API keys mutate via `@repo/core` / `@repo/react` → Fastify. Do **not** rewrite them as Next.js Server Actions.
+- Pending/optimistic UI stays on TanStack mutation flags; do **not** rewrite to `useFormStatus` / `useOptimistic`.
 - Next API routes exist only for SSR/cookie integration (`update-tokens`, auth callbacks, logout).
 
 ## Auth Protection (proxy.ts)

--- a/apps/docu/content/docs/architecture/frontend.mdx
+++ b/apps/docu/content/docs/architecture/frontend.mdx
@@ -69,6 +69,8 @@ Stream with `loading.tsx` and Suspense. Mark search/filter updates as transition
 
 Forms and hooks call the shared API client (`@repo/core`, `@repo/react`) which hits Fastify directly. Next.js routes exist only for SSR and cookie integration — auth callbacks, logout, and `POST /api/auth/update-tokens` (same-origin, Fastify-validated before `Set-Cookie`). Do not migrate login or settings mutations to `'use server'`.
 
+Pending and optimistic UI for mutations stays on TanStack mutation flags (`isPending`, `isError`); do not rewrite forms to `useFormStatus` or `useOptimistic`.
+
 ## Data and state
 
 | Concern | Library |

--- a/apps/web/e2e/update-tokens.spec.ts
+++ b/apps/web/e2e/update-tokens.spec.ts
@@ -19,8 +19,8 @@ async function setCookieHeaders(response: HeadersArrayResponse) {
 }
 
 async function hasAuthSessionSetCookie(response: HeadersArrayResponse) {
-  const prefix = `${authCookieName.toLowerCase()}=`
-  return (await setCookieHeaders(response)).some(value => value.toLowerCase().startsWith(prefix))
+  const prefix = `${authCookieName}=`
+  return (await setCookieHeaders(response)).some(value => value.startsWith(prefix))
 }
 
 function parseSessionCookieValue(setCookieValue: string) {

--- a/apps/web/e2e/update-tokens.spec.ts
+++ b/apps/web/e2e/update-tokens.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { authHelpers } from './auth-helpers'
 
 const authCookieName =
   process.env.NEXT_PUBLIC_AUTH_COOKIE_NAME ?? process.env.AUTH_COOKIE_NAME ?? 'api.session'
@@ -8,13 +9,59 @@ const appUrl =
 
 const sameOrigin = new URL(appUrl).origin
 
-function sessionSetCookie(headers: Record<string, string>) {
-  const raw = headers['set-cookie'] ?? headers['Set-Cookie']
-  if (!raw) return undefined
-  return Array.isArray(raw) ? raw.join('; ') : raw
+type HeadersArrayResponse = {
+  headersArray: () => { name: string; value: string }[] | Promise<{ name: string; value: string }[]>
+}
+
+async function setCookieHeaders(response: HeadersArrayResponse) {
+  const headers = await response.headersArray()
+  return headers.filter(h => h.name.toLowerCase() === 'set-cookie').map(h => h.value)
+}
+
+async function hasAuthSessionSetCookie(response: HeadersArrayResponse) {
+  const prefix = `${authCookieName.toLowerCase()}=`
+  return (await setCookieHeaders(response)).some(value => value.toLowerCase().startsWith(prefix))
+}
+
+function parseSessionCookieValue(setCookieValue: string) {
+  const match = setCookieValue.match(new RegExp(`^${authCookieName}=([^;]+)`, 'i'))
+  if (!match?.[1]) return null
+  try {
+    return JSON.parse(decodeURIComponent(match[1])) as {
+      token?: string
+      refreshToken?: string
+    }
+  } catch {
+    try {
+      return JSON.parse(match[1]) as { token?: string; refreshToken?: string }
+    } catch {
+      return null
+    }
+  }
 }
 
 test.describe('POST /api/auth/update-tokens', () => {
+  test('sets validated session cookie on first login', async ({ page }) => {
+    const updateTokensResponse = page.waitForResponse(
+      resp => resp.url().includes('/api/auth/update-tokens') && resp.request().method() === 'POST',
+      { timeout: 60_000 },
+    )
+
+    await authHelpers.loginAsTestUser(page)
+
+    const response = await updateTokensResponse
+    expect(response.status()).toBe(200)
+
+    const sessionHeader = (await setCookieHeaders(response)).find(value =>
+      value.toLowerCase().startsWith(`${authCookieName.toLowerCase()}=`),
+    )
+    expect(sessionHeader).toBeDefined()
+
+    const parsed = parseSessionCookieValue(sessionHeader ?? '')
+    expect(parsed?.token).toBeTruthy()
+    expect(parsed?.refreshToken).toBeTruthy()
+  })
+
   test('returns 400 for missing fields', async ({ request }) => {
     const response = await request.post('/api/auth/update-tokens', {
       headers: { Origin: sameOrigin, 'Content-Type': 'application/json' },
@@ -22,18 +69,17 @@ test.describe('POST /api/auth/update-tokens', () => {
     })
 
     expect(response.status()).toBe(400)
-    expect(sessionSetCookie(response.headers())).toBeUndefined()
+    expect(await hasAuthSessionSetCookie(response)).toBe(false)
   })
 
-  test('returns 401 for garbage tokens', async ({ request }) => {
+  test('returns 401 for garbage tokens without setting session cookie', async ({ request }) => {
     const response = await request.post('/api/auth/update-tokens', {
       headers: { Origin: sameOrigin, 'Content-Type': 'application/json' },
       data: { token: 'garbage-access', refreshToken: 'garbage-refresh' },
     })
 
     expect(response.status()).toBe(401)
-    const setCookie = sessionSetCookie(response.headers())
-    expect(setCookie).toBeUndefined()
+    expect(await hasAuthSessionSetCookie(response)).toBe(false)
   })
 
   test('returns 403 for foreign Origin', async ({ request }) => {
@@ -43,8 +89,7 @@ test.describe('POST /api/auth/update-tokens', () => {
     })
 
     expect(response.status()).toBe(403)
-    const setCookie = sessionSetCookie(response.headers())
-    expect(setCookie).toBeUndefined()
+    expect(await hasAuthSessionSetCookie(response)).toBe(false)
   })
 
   test('returns 403 when Origin is absent', async ({ request }) => {
@@ -54,18 +99,20 @@ test.describe('POST /api/auth/update-tokens', () => {
     })
 
     expect(response.status()).toBe(403)
-    const setCookie = sessionSetCookie(response.headers())
-    expect(setCookie).toBeUndefined()
+    expect(await hasAuthSessionSetCookie(response)).toBe(false)
   })
 
-  test('does not set session cookie on 401', async ({ request }) => {
+  test('returns 403 for cross-site Sec-Fetch-Site', async ({ request }) => {
     const response = await request.post('/api/auth/update-tokens', {
-      headers: { Origin: sameOrigin, 'Content-Type': 'application/json' },
+      headers: {
+        Origin: sameOrigin,
+        'Sec-Fetch-Site': 'cross-site',
+        'Content-Type': 'application/json',
+      },
       data: { token: 'garbage-access', refreshToken: 'garbage-refresh' },
     })
 
-    expect(response.status()).toBe(401)
-    const setCookie = sessionSetCookie(response.headers()) ?? ''
-    expect(setCookie.includes(`${authCookieName}=`)).toBe(false)
+    expect(response.status()).toBe(403)
+    expect(await hasAuthSessionSetCookie(response)).toBe(false)
   })
 })


### PR DESCRIPTION
Document TanStack pending flags as the accepted mutation pattern and harden update-tokens E2E with login happy-path and Sec-Fetch-Site checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that mutation pending and error states should use TanStack mutation flags.
  * Documented that forms should not rely on alternative optimistic UI status mechanisms.

* **Tests**
  * Expanded authentication token update coverage, including first-login session cookies.
  * Improved validation of session cookies across error responses.
  * Added coverage for cross-site request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->