### PR TITLE
fix(api): close chat SSRF and passkey catalog gaps

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -2362,7 +2362,20 @@
                           ],
                           "properties": {
                             "role": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "user"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "assistant"
+                                  ]
+                                }
+                              ]
                             },
                             "content": {
                               "maxLength": 32000,
@@ -2381,7 +2394,20 @@
                           ],
                           "properties": {
                             "role": {
-                              "type": "string"
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "user"
+                                  ]
+                                },
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "assistant"
+                                  ]
+                                }
+                              ]
                             },
                             "parts": {
                               "maxItems": 64,
@@ -2450,6 +2476,7 @@
                                       },
                                       "url": {
                                         "maxLength": 2048,
+                                        "pattern": "^data:",
                                         "type": "string"
                                       },
                                       "filename": {

--- a/apps/api/src/lib/ai/download.ts
+++ b/apps/api/src/lib/ai/download.ts
@@ -1,0 +1,12 @@
+import { DownloadError, type Experimental_DownloadFunction } from 'ai'
+
+export const denyRemoteChatFileDownload: Experimental_DownloadFunction = requestedDownloads =>
+  Promise.all(
+    requestedDownloads.map(({ url }) => {
+      if (url.protocol === 'data:') return null
+      throw new DownloadError({
+        url: url.toString(),
+        message: 'Remote file URLs are not allowed',
+      })
+    }),
+  )

--- a/apps/api/src/lib/ai/index.ts
+++ b/apps/api/src/lib/ai/index.ts
@@ -1,4 +1,5 @@
-export { type ResolveMessagesResult, resolveMessages } from './messages.js'
+export { denyRemoteChatFileDownload } from './download.js'
+export { isAllowedChatFileUrl, type ResolveMessagesResult, resolveMessages } from './messages.js'
 export {
   defaultAnthropicModel,
   defaultOllamaModel,

--- a/apps/api/src/lib/ai/messages.spec.ts
+++ b/apps/api/src/lib/ai/messages.spec.ts
@@ -1,0 +1,1 @@
+import './messages.test.js'

--- a/apps/api/src/lib/ai/messages.test.ts
+++ b/apps/api/src/lib/ai/messages.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isAllowedChatFileUrl } from './messages.js'
+
+describe('isAllowedChatFileUrl', () => {
+  it('allows data: URLs', () => {
+    expect(isAllowedChatFileUrl({ url: 'data:image/png;base64,abc' })).toBe(true)
+  })
+
+  it('rejects http loopback', () => {
+    expect(isAllowedChatFileUrl({ url: 'http://127.0.0.1/' })).toBe(false)
+  })
+
+  it('rejects cloud metadata endpoint', () => {
+    expect(isAllowedChatFileUrl({ url: 'http://169.254.169.254/' })).toBe(false)
+  })
+
+  it('rejects https remote URLs', () => {
+    expect(isAllowedChatFileUrl({ url: 'https://example.com/x.png' })).toBe(false)
+  })
+
+  it('rejects file: URLs', () => {
+    expect(isAllowedChatFileUrl({ url: 'file:///etc/passwd' })).toBe(false)
+  })
+
+  it('rejects unparseable URLs', () => {
+    expect(isAllowedChatFileUrl({ url: 'not-a-valid-file-url' })).toBe(false)
+  })
+})

--- a/apps/api/src/lib/ai/messages.ts
+++ b/apps/api/src/lib/ai/messages.ts
@@ -4,6 +4,14 @@ export type ResolveMessagesResult =
   | { ok: true; messages: ModelMessage[] }
   | { ok: false; message: string }
 
+export function isAllowedChatFileUrl({ url }: { url: string }): boolean {
+  try {
+    return new URL(url).protocol === 'data:'
+  } catch {
+    return false
+  }
+}
+
 function isUIMessage(msg: unknown): msg is { role: string; parts: unknown[] } {
   return (
     typeof msg === 'object' &&
@@ -30,6 +38,26 @@ function hasSystemRole(messages: unknown[]): boolean {
   })
 }
 
+function validateUIMessageFileUrls(messages: unknown[]): ResolveMessagesResult | null {
+  for (const msg of messages) {
+    if (!isUIMessage(msg)) continue
+    for (const part of msg.parts) {
+      if (
+        typeof part !== 'object' ||
+        part === null ||
+        !('type' in part) ||
+        (part as { type: string }).type !== 'file' ||
+        !('url' in part)
+      )
+        continue
+      const url = (part as { url: unknown }).url
+      if (typeof url !== 'string' || !isAllowedChatFileUrl({ url }))
+        return { ok: false, message: 'Invalid request: file URL must be a data: URL' }
+    }
+  }
+  return null
+}
+
 export async function resolveMessages(
   rawMessages: unknown[],
   tools: ToolSet,
@@ -42,6 +70,9 @@ export async function resolveMessages(
     const allUIMessage = rawMessages.every(isUIMessage)
     if (!allUIMessage)
       return { ok: false, message: 'Invalid request: mixed UIMessage and CoreMessage formats' }
+
+    const fileUrlError = validateUIMessageFileUrls(rawMessages)
+    if (fileUrlError) return fileUrlError
 
     try {
       const messages = await convertToModelMessages(

--- a/apps/api/src/lib/passkey/auth.ts
+++ b/apps/api/src/lib/passkey/auth.ts
@@ -3,6 +3,7 @@ import { verifyAuthenticationResponse } from '@simplewebauthn/server'
 import { eq } from 'drizzle-orm'
 import { getDb } from '../../db/index.js'
 import { passkeyCredentials } from '../../db/schema/index.js'
+import { type ErrorCode, getError } from '../catalogs/mapper.js'
 
 const validTransports = ['ble', 'cable', 'hybrid', 'internal', 'nfc', 'smart-card', 'usb'] as const
 type AuthenticatorTransportFuture = (typeof validTransports)[number]
@@ -15,9 +16,12 @@ function filterTransports(arr: string[] | null): AuthenticatorTransportFuture[] 
   )
 }
 
-export type VerifyPasskeyAuthResult =
-  | { ok: true; userId: string }
-  | { ok: false; code: string; message: string }
+export type VerifyPasskeyAuthResult = { ok: true; userId: string } | { ok: false; code: ErrorCode }
+
+function catalogFailure(code: ErrorCode): { ok: false; code: ErrorCode } {
+  getError(code)
+  return { ok: false, code }
+}
 
 export async function verifyPasskeyAuth({
   assertion,
@@ -31,8 +35,7 @@ export async function verifyPasskeyAuth({
   expectedRPID: string
 }): Promise<VerifyPasskeyAuthResult> {
   const credentialId = assertion.id
-  if (!credentialId)
-    return { ok: false, code: 'MISSING_CREDENTIAL_ID', message: 'Assertion missing credential id' }
+  if (!credentialId) return catalogFailure('MISSING_CREDENTIAL_ID')
 
   const db = await getDb()
   const [credential] = await db
@@ -41,16 +44,12 @@ export async function verifyPasskeyAuth({
     .where(eq(passkeyCredentials.credentialId, credentialId))
     .limit(1)
 
-  if (!credential) return { ok: false, code: 'UNKNOWN_CREDENTIAL', message: 'Credential not found' }
+  if (!credential) return catalogFailure('UNKNOWN_CREDENTIAL')
 
   const publicKey = Buffer.from(credential.publicKey, 'base64')
   const counter = credential.counter
   if (!Number.isInteger(counter) || Number.isNaN(counter) || counter < 0)
-    return {
-      ok: false,
-      code: 'INVALID_COUNTER',
-      message: 'Invalid credential counter',
-    }
+    return catalogFailure('INVALID_COUNTER')
 
   let verification: Awaited<ReturnType<typeof verifyAuthenticationResponse>>
   try {
@@ -66,16 +65,12 @@ export async function verifyPasskeyAuth({
         transports: filterTransports(credential.transports) ?? undefined,
       },
     })
-  } catch (err) {
-    return {
-      ok: false,
-      code: 'VERIFICATION_FAILED',
-      message: err instanceof Error ? err.message : 'Verification failed',
-    }
+  } catch {
+    return catalogFailure('VERIFICATION_FAILED')
   }
 
   if (!verification.verified || !verification.authenticationInfo)
-    return { ok: false, code: 'VERIFICATION_FAILED', message: 'Verification failed' }
+    return catalogFailure('VERIFICATION_FAILED')
 
   const [updated] = await db
     .update(passkeyCredentials)
@@ -83,12 +78,7 @@ export async function verifyPasskeyAuth({
     .where(eq(passkeyCredentials.id, credential.id))
     .returning()
 
-  if (!updated)
-    return {
-      ok: false,
-      code: 'COUNTER_UPDATE_FAILED',
-      message: 'Failed to update credential counter',
-    }
+  if (!updated) return catalogFailure('COUNTER_UPDATE_FAILED')
 
   return { ok: true, userId: credential.userId }
 }

--- a/apps/api/src/plugins/jwt.ts
+++ b/apps/api/src/plugins/jwt.ts
@@ -6,9 +6,13 @@ import { env } from '../lib/env.js'
 const jwtPlugin: FastifyPluginAsync = async fastify => {
   await fastify.register(fastifyJwt, {
     secret: env.JWT_SECRET,
+    sign: {
+      algorithm: 'HS256',
+    },
     verify: {
       allowedIss: env.JWT_ISSUER,
       allowedAud: env.JWT_AUDIENCE,
+      algorithms: ['HS256'],
     },
   })
 }

--- a/apps/api/src/routes/ai/chat.test.ts
+++ b/apps/api/src/routes/ai/chat.test.ts
@@ -135,6 +135,53 @@ describe('POST /ai/chat', () => {
       expect(data.code).toBe('BAD_REQUEST')
     })
 
+    it('should return 400 for UIMessage with https file URL', async () => {
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/ai/chat',
+        headers: {
+          Authorization: `Bearer ${testToken}`,
+        },
+        payload: {
+          messages: [
+            {
+              role: 'user',
+              parts: [
+                {
+                  type: 'file',
+                  mediaType: 'image/png',
+                  url: 'https://example.com/x.png',
+                },
+              ],
+            },
+          ],
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+      const data = JSON.parse(response.body)
+      expect(() => ErrorSchema.parse(data)).not.toThrow()
+      expect(data.code).toBe('BAD_REQUEST')
+    })
+
+    it('should return 400 for tool role messages', async () => {
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/ai/chat',
+        headers: {
+          Authorization: `Bearer ${testToken}`,
+        },
+        payload: {
+          messages: [{ role: 'tool', content: 'tool output' }],
+        },
+      })
+
+      expect(response.statusCode).toBe(400)
+      const data = JSON.parse(response.body)
+      expect(() => ErrorSchema.parse(data)).not.toThrow()
+      expect(data.code).toBe('BAD_REQUEST')
+    })
+
     it('should return 400 for missing required messages field', async () => {
       const response = await fastify.inject({
         method: 'POST',

--- a/apps/api/src/routes/ai/chat.ts
+++ b/apps/api/src/routes/ai/chat.ts
@@ -5,6 +5,7 @@ import type { FastifyPluginAsync } from 'fastify'
 import {
   createRequestAbortSignal,
   createUiMessageStreamResponse,
+  denyRemoteChatFileDownload,
   getMergedTools,
   getProvider,
   getResolvedProvider,
@@ -18,6 +19,7 @@ import { ErrorResponseSchema } from '../schemas.js'
 
 const chatMessageTextMaxLength = 32_000
 const chatMessagePartsMaxItems = 64
+const chatMessageRoleSchema = Type.Union([Type.Literal('user'), Type.Literal('assistant')])
 
 const ChatMessagePartSchema = Type.Union([
   Type.Object({
@@ -32,7 +34,7 @@ const ChatMessagePartSchema = Type.Union([
   Type.Object({
     type: Type.Literal('file'),
     mediaType: Type.String({ maxLength: 256 }),
-    url: Type.String({ maxLength: 2048 }),
+    url: Type.String({ maxLength: 2048, pattern: '^data:' }),
     filename: Type.Optional(Type.String({ maxLength: 256 })),
   }),
   Type.Object({
@@ -51,12 +53,12 @@ const ChatMessagePartSchema = Type.Union([
 
 const ChatMessageItemSchema = Type.Union([
   Type.Object({
-    role: Type.String(),
+    role: chatMessageRoleSchema,
     content: Type.String({ maxLength: chatMessageTextMaxLength }),
     name: Type.Optional(Type.String()),
   }),
   Type.Object({
-    role: Type.String(),
+    role: chatMessageRoleSchema,
     parts: Type.Array(ChatMessagePartSchema, { maxItems: chatMessagePartsMaxItems }),
   }),
 ])
@@ -108,12 +110,10 @@ const chatRoute: FastifyPluginAsync = async fastify => {
       if (!session) return sendCatalogError({ reply, status: 401, code: 'UNAUTHORIZED' })
 
       const provider = getResolvedProvider()
-      if (!provider)
-        return reply.code(500).send({
-          code: 'SERVER_ERROR',
-          message:
-            'No AI provider configured. Set ANTHROPIC_API_KEY (default), OPEN_ROUTER_API_KEY, or OLLAMA_BASE_URL.',
-        })
+      if (!provider) {
+        request.log.warn('No AI provider configured')
+        return sendCatalogError({ reply, status: 500, code: 'SERVER_ERROR' })
+      }
 
       const { messages: rawMessages, stream, model, temperature } = request.body
       const resolvedModel = getProvider(provider, model)
@@ -144,6 +144,7 @@ const chatRoute: FastifyPluginAsync = async fastify => {
         tools: mergedTools,
         stopWhen: isStepCount(env.AI_TOOL_MAX_STEPS),
         abortSignal,
+        experimental_download: denyRemoteChatFileDownload,
         ...(temperature !== undefined && { temperature }),
       }
 

--- a/apps/api/src/routes/ai/generate.ts
+++ b/apps/api/src/routes/ai/generate.ts
@@ -58,12 +58,10 @@ const generateRoute: FastifyPluginAsync = async fastify => {
       if (!request.session) return sendCatalogError({ reply, status: 401, code: 'UNAUTHORIZED' })
 
       const provider = getResolvedProvider()
-      if (!provider)
-        return reply.code(500).send({
-          code: 'SERVER_ERROR',
-          message:
-            'No AI provider configured. Set ANTHROPIC_API_KEY (default), OPEN_ROUTER_API_KEY, or OLLAMA_BASE_URL.',
-        })
+      if (!provider) {
+        request.log.warn('No AI provider configured')
+        return sendCatalogError({ reply, status: 500, code: 'SERVER_ERROR' })
+      }
 
       const { prompt: rawPrompt, stream, model, temperature } = request.body
       const prompt = rawPrompt.trim()

--- a/apps/api/src/routes/auth/passkey/verify.ts
+++ b/apps/api/src/routes/auth/passkey/verify.ts
@@ -6,6 +6,7 @@ import type { FastifyPluginAsync } from 'fastify'
 import { encryptCallbackTokens } from '../../../db/callback-tokens.js'
 import { getDb } from '../../../db/index.js'
 import { passkeyAuthChallenges, passkeyCallback } from '../../../db/schema/index.js'
+import { sendCatalogError } from '../../../lib/catalogs/mapper.js'
 import { generateToken, hashToken } from '../../../lib/jwt.js'
 import {
   AuthenticationResponseJSONSchema,
@@ -92,7 +93,7 @@ const passkeyVerifyRoute: FastifyPluginAsync = async fastify => {
         expectedRPID: origin.rpID,
       })
 
-      if (!result.ok) return reply.code(401).send({ code: result.code, message: result.message })
+      if (!result.ok) return sendCatalogError({ reply, status: 401, code: result.code })
 
       if (callbackUrl) {
         const callbackOrigin = new URL(callbackUrl).origin

--- a/apps/docu/content/docs/architecture/ai.mdx
+++ b/apps/docu/content/docs/architecture/ai.mdx
@@ -37,7 +37,9 @@ apps/api/src/lib/ai/
 
 Chat uses `streamText` / `generateText` with `stopWhen: isStepCount(AI_TOOL_MAX_STEPS)`. Generate is prompt-only (no tools). Shared runtime handles client abort + `AI_UPSTREAM_TIMEOUT_MS`, v7 UI streams (`toUIMessageStream` + `createUIMessageStreamResponse`), and catalog errors via `captureError` then `sendCatalogError`.
 
-Client `{ role: 'system' }` messages are rejected with 400 — system prompt belongs server-side (`instructions`), not in client payloads.
+Client `{ role: 'system' }` messages are rejected with 400 — system prompt belongs server-side (`instructions`), not in client payloads. Client roles are limited to `user` and `assistant`; `tool` and other roles return 400.
+
+File parts in UIMessage payloads must use `data:` URLs only (`maxLength` 2048). Remote URLs (`http:`, `https:`, `file:`, etc.) are rejected at validation with 400 before the handler runs. The chat route also blocks server-side fetches of non-`data:` file URLs via `experimental_download`.
 
 ## Environment variables
 

--- a/apps/docu/content/docs/architecture/security.mdx
+++ b/apps/docu/content/docs/architecture/security.mdx
@@ -52,6 +52,8 @@ Lockfile integrity (`--frozen-lockfile`), gitleaks, TruffleHog (filesystem + his
 - CORS: `ALLOWED_ORIGINS` must be explicit origins in production (boot fails on `*` or empty). Fastify [`plugins/cors.ts`](https://github.com/blockmatic/basilic/blob/main/apps/api/src/plugins/cors.ts) is the source of truth — do not set `Access-Control-Allow-Origin` in `vercel.json` or other deployment headers. Dev/test may use `*`.
 - Rate limit: in-memory per client IP (`RATE_LIMIT_MAX` / `RATE_LIMIT_TIME_WINDOW`). Behind a reverse proxy, set `TRUST_PROXY=true` so Fastify honors `X-Forwarded-For` (Fastify 5 treats numeric hop counts as fail-closed). Local-only, not shared across instances.
 - Validation: **TypeBox** on Fastify routes. Suspicious URL/user-agent patterns are logged in `apps/api/src/lib/security.ts` (not blocked; rate limits handle abuse).
+- JWT access and refresh tokens are signed and verified with **HS256** only (`@fastify/jwt`).
+- `POST /ai/chat` does not fetch client-supplied file URLs; only `data:` file parts are accepted. Remote URLs are rejected at validation.
 - 6-digit login codes (magic link, change email): HMAC-SHA256 with `ENCRYPTION_KEY`. API keys and other high-entropy tokens: SHA-256 at rest with `timingSafeEqual` on verify.
 
 ## Login route rate limit (as shipped)

--- a/packages/core/src/gen/types.gen.ts
+++ b/packages/core/src/gen/types.gen.ts
@@ -838,11 +838,11 @@ export type AccountProfileUpdateResponse = AccountProfileUpdateResponses[keyof A
 export type ChatData = {
   body: {
     messages: Array<{
-      role: string;
+      role: 'user' | 'assistant';
       content: string;
       name?: string;
     } | {
-      role: string;
+      role: 'user' | 'assistant';
       parts: Array<{
         type: 'text';
         text: string;


### PR DESCRIPTION
## Summary

Follow-up to #168 — closes remaining API security items from the review plan:

- **Chat SSRF**: TypeBox restricts file `url` to `data:` and `role` to `user`|`assistant`; `isAllowedChatFileUrl` validates UIMessage parts before conversion; `experimental_download` on chat `streamText`/`generateText` rejects remote URLs (does not pass through via `null`).
- **JWT**: Pin `@fastify/jwt` sign/verify to **HS256** only.
- **Passkey login verify**: `verifyPasskeyAuth` returns catalog codes only; route uses `sendCatalogError` (no SimpleWebAuthn `err.message` in HTTP bodies).
- **Missing AI provider**: `chat` and `generate` log a warning and return catalog `SERVER_ERROR` without naming env vars.

Docs updated in `ai.mdx` and `security.mdx`. OpenAPI + `@repo/core` regenerated.

## Test plan

- [x] `pnpm --filter @repo/api test` (284 passed)
- [x] `pnpm --filter @repo/api checktypes`
- [x] `pnpm generate`
- [x] New unit tests: `messages.spec.ts` (`isAllowedChatFileUrl`)
- [x] New inject tests: `https://` file URL → 400 `BAD_REQUEST`; `role: 'tool'` → 400 `BAD_REQUEST`