### PR TITLE
ci: optimize test workflows and add vitest coverage

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,14 @@
+name: Setup pnpm
+description: Install pnpm, Node from .nvmrc, and dependencies with frozen lockfile
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 11.24.0
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: .nvmrc
+        cache: pnpm
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/api-e2e.yml
+++ b/.github/workflows/api-e2e.yml
@@ -55,6 +55,8 @@ jobs:
             ${{ runner.os }}-playwright-
       - name: Install Playwright
         run: pnpm --filter @repo/api exec playwright install chromium --with-deps
+      - name: Build API dependencies
+        run: pnpm turbo run build --filter=@repo/api...
       - name: E2E tests (local)
         run: pnpm --filter @repo/api test:e2e:local
       - name: Upload Playwright report

--- a/.github/workflows/api-e2e.yml
+++ b/.github/workflows/api-e2e.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: api-e2e-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   NODE_ENV: test
@@ -23,37 +23,30 @@ env:
   PGLITE: true
   DATABASE_URL: postgresql://localhost/test
   JWT_SECRET: e2e-jwt-secret-min-32-chars-for-tests
-  AI_PROVIDER: anthropic
-  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
 jobs:
-  build-and-test:
+  unit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.24.0
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-      - uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - name: Check OpenAPI drift
         run: pnpm generate && git diff --exit-code -- apps/api/openapi/openapi.json packages/core/src/gen
-      - name: Build
-        run: pnpm turbo run build --filter=@repo/api...
-      - name: Unit tests
-        run: pnpm turbo run test --filter=@repo/api
+      - name: Unit tests with coverage
+        run: pnpm --filter @repo/api test:cov
+      - name: Upload Vitest coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-vitest-coverage
+          path: apps/api/coverage/
+          retention-days: 30
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
       - uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
@@ -62,16 +55,6 @@ jobs:
             ${{ runner.os }}-playwright-
       - name: Install Playwright
         run: pnpm --filter @repo/api exec playwright install chromium --with-deps
-      - name: Verify ANTHROPIC_API_KEY for E2E (AI_PROVIDER=anthropic)
-        shell: bash
-        env:
-          AI_PROVIDER: ${{ env.AI_PROVIDER }}
-          ANTHROPIC_API_KEY: ${{ env.ANTHROPIC_API_KEY }}
-        run: |
-          if [[ "${AI_PROVIDER}" == "anthropic" && -z "${ANTHROPIC_API_KEY}" ]]; then
-            echo "::error::AI_PROVIDER is anthropic but ANTHROPIC_API_KEY is empty or unset. Set the ANTHROPIC_API_KEY repository secret; required before E2E tests (local)." >&2
-            exit 1
-          fi
       - name: E2E tests (local)
         run: pnpm --filter @repo/api test:e2e:local
       - name: Upload Playwright report

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,31 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.24.0
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Run lint
         run: pnpm lint

--- a/.github/workflows/packages-test.yml
+++ b/.github/workflows/packages-test.yml
@@ -26,23 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.24.0
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-      - uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
       - name: Build packages
         run: pnpm turbo run build --filter='!@repo/web' --filter='!@repo/api' --filter='!@repo/docu'
       - name: Unit tests (packages only)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,31 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.24.0
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Run gitleaks (full repo scan)
         uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: web-e2e-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   NODE_ENV: test
@@ -40,33 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.24.0
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-      - uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+      - uses: ./.github/actions/setup-pnpm
       - uses: actions/cache@v4
         with:
           path: apps/web/.next/cache
           key: ${{ runner.os }}-next-web-${{ hashFiles('**/pnpm-lock.yaml', 'apps/web/**', 'packages/ui/**', 'packages/core/**', 'packages/react/**', 'packages/utils/**', 'packages/error/**') }}
           restore-keys: |
             ${{ runner.os }}-next-web-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Build
         run: pnpm turbo run build --filter=@repo/web...
-      - name: Web test script (E2E only placeholder)
-        run: pnpm turbo run test --filter=@repo/web
       - uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright

--- a/apps/api/scripts/run-e2e-local.mjs
+++ b/apps/api/scripts/run-e2e-local.mjs
@@ -70,6 +70,7 @@ async function main() {
     NODE_ENV: 'test',
     RATE_LIMIT_MAX: '10000',
     WEBAUTHN_RP_NAME: loaded.WEBAUTHN_RP_NAME ?? process.env.WEBAUTHN_RP_NAME ?? 'Test App',
+    TOTP_ISSUER: loaded.TOTP_ISSUER ?? process.env.TOTP_ISSUER ?? 'Test App',
     JWT_SECRET: jwtSecret,
   }
   delete env.OPEN_ROUTER_API_KEY
@@ -81,7 +82,7 @@ async function main() {
   const fastify = spawn(process.execPath, ['--import', 'tsx', 'server.ts'], {
     cwd: fastifyDir,
     env,
-    stdio: 'ignore',
+    stdio: ['ignore', 'ignore', 'inherit'],
   })
 
   fastify.on('error', err => {

--- a/apps/api/scripts/run-e2e-local.mjs
+++ b/apps/api/scripts/run-e2e-local.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * E2E local: spawn Fastify API, poll until healthy, run Playwright, cleanup on exit.
- * No wait-on. Uses ALLOW_TEST, PGLITE, NODE_ENV=test.
- * Forces AI_PROVIDER=anthropic and strips Open Router/Ollama/AI_DEFAULT_MODEL (parity with Vitest + web E2E).
+ * No wait-on. Uses ALLOW_TEST, PGLITE, NODE_ENV=test, RATE_LIMIT_MAX=10000.
+ * Scalar login E2E does not call AI; Anthropic is not required for this spawn.
  */
 import { spawn, spawnSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
@@ -62,27 +62,21 @@ async function main() {
   const loaded = loadEnvTest()
   const jwtSecret =
     loaded.JWT_SECRET ?? process.env.JWT_SECRET ?? 'e2e-jwt-secret-min-32-chars-for-tests'
-  const anthropicApiKey = loaded.ANTHROPIC_API_KEY ?? process.env.ANTHROPIC_API_KEY
-  if (!anthropicApiKey) {
-    process.stderr.write(
-      'E2E local: ANTHROPIC_API_KEY must be set in .env.test or process.env when AI_PROVIDER is anthropic. Refusing to run without it.\n',
-    )
-    process.exit(1)
-  }
   const env = {
     ...process.env,
     ...loaded,
     ALLOW_TEST: 'true',
     PGLITE: 'true',
     NODE_ENV: 'test',
+    RATE_LIMIT_MAX: '10000',
     WEBAUTHN_RP_NAME: loaded.WEBAUTHN_RP_NAME ?? process.env.WEBAUTHN_RP_NAME ?? 'Test App',
     JWT_SECRET: jwtSecret,
-    AI_PROVIDER: 'anthropic',
-    ANTHROPIC_API_KEY: anthropicApiKey,
   }
   delete env.OPEN_ROUTER_API_KEY
   delete env.OLLAMA_BASE_URL
   delete env.AI_DEFAULT_MODEL
+  delete env.AI_PROVIDER
+  delete env.ANTHROPIC_API_KEY
 
   const fastify = spawn(process.execPath, ['--import', 'tsx', 'server.ts'], {
     cwd: fastifyDir,

--- a/apps/api/src/routes/ai/chat.test.ts
+++ b/apps/api/src/routes/ai/chat.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import {
+  hasRealAnthropicKey,
   skipIfInsufficientCredits,
   skipIfProviderUnavailable,
 } from '../../../test/utils/ai-remote.js'
@@ -274,7 +275,7 @@ describe('POST /ai/chat', () => {
     })
   })
 
-  describe('POST /ai/chat — remote', () => {
+  describe.skipIf(!hasRealAnthropicKey())('POST /ai/chat — remote', () => {
     it('should accept UIMessage text part within the limit', async ctx => {
       const response = await fastify.inject({
         method: 'POST',

--- a/apps/api/src/routes/ai/generate.test.ts
+++ b/apps/api/src/routes/ai/generate.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import {
+  hasRealAnthropicKey,
   skipIfInsufficientCredits,
   skipIfProviderUnavailable,
 } from '../../../test/utils/ai-remote.js'
@@ -83,7 +84,7 @@ describe('POST /ai/generate', () => {
     })
   })
 
-  describe('POST /ai/generate — remote', () => {
+  describe.skipIf(!hasRealAnthropicKey())('POST /ai/generate — remote', () => {
     it('should return 200 non-streaming with text', async ctx => {
       const response = await fastify.inject({
         method: 'POST',

--- a/apps/api/src/routes/ai/generate.ts
+++ b/apps/api/src/routes/ai/generate.ts
@@ -57,15 +57,15 @@ const generateRoute: FastifyPluginAsync = async fastify => {
     async (request, reply) => {
       if (!request.session) return sendCatalogError({ reply, status: 401, code: 'UNAUTHORIZED' })
 
+      const { prompt: rawPrompt, stream, model, temperature } = request.body
+      const prompt = rawPrompt.trim()
+      if (!prompt) return sendCatalogError({ reply, status: 400, code: 'BAD_REQUEST' })
+
       const provider = getResolvedProvider()
       if (!provider) {
         request.log.warn('No AI provider configured')
         return sendCatalogError({ reply, status: 500, code: 'SERVER_ERROR' })
       }
-
-      const { prompt: rawPrompt, stream, model, temperature } = request.body
-      const prompt = rawPrompt.trim()
-      if (!prompt) return sendCatalogError({ reply, status: 400, code: 'BAD_REQUEST' })
 
       const resolvedModel = getProvider(provider, model)
 

--- a/apps/api/test/utils/ai-remote.ts
+++ b/apps/api/test/utils/ai-remote.ts
@@ -25,9 +25,11 @@ const isConnectionClassFailure = (res: ResponseLike): boolean =>
 export const isProviderUnavailable = (res: ResponseLike): boolean =>
   res.statusCode === 502 || isConnectionClassFailure(res)
 
-const isPlaceholderAnthropicKey = (): boolean => {
+export const hasRealAnthropicKey = (): boolean => {
   const key = process.env.ANTHROPIC_API_KEY
-  return !key || key === 'sk-ant-xxx'
+  if (!key || key === 'sk-ant-xxx') return false
+  if (key.startsWith('sk-ant-dummy')) return false
+  return true
 }
 
 export const skipIfProviderUnavailable = (
@@ -35,7 +37,7 @@ export const skipIfProviderUnavailable = (
   res: ResponseLike,
   name: string,
 ): void => {
-  if (!isPlaceholderAnthropicKey() && isProviderUnavailable(res)) return
+  if (hasRealAnthropicKey()) return
   if (isProviderUnavailable(res))
     ctx.skip(`[AI test] ${name}: AI provider unreachable (${res.statusCode})`)
 }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -139,6 +139,12 @@ export default defineConfig({
     fileParallelism: false,
     maxWorkers: 1,
     sequence: { concurrent: false },
+    coverage: {
+      provider: 'v8',
+      include: ['src/**'],
+      exclude: ['**/*.{test,spec}.ts', 'src/db/migrations/**', 'src/routes/reference/template*.ts'],
+      reporter: ['text', 'html', 'lcov'],
+    },
   },
   resolve: {
     // Order matters: try .ts first, then .js

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -142,7 +142,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**'],
-      exclude: ['**/*.{test,spec}.ts', 'src/db/migrations/**', 'src/routes/reference/template*.ts'],
+      exclude: [
+        '**/*.{test,spec}.ts',
+        '**/*.md',
+        'src/db/migrations/**',
+        'src/routes/reference/template*.ts',
+      ],
       reporter: ['text', 'html', 'lcov'],
     },
   },

--- a/apps/docu/content/docs/deployment/github-actions.mdx
+++ b/apps/docu/content/docs/deployment/github-actions.mdx
@@ -17,7 +17,7 @@ Build → E2E. Triggers on pull request when `apps/web/**`, `apps/api/src/routes
 
 Two parallel jobs when `apps/api/**` or shared packages change:
 
-- **unit** — OpenAPI drift check (`pnpm generate && git diff --exit-code`), then `pnpm --filter @repo/api test:cov`. Uploads `api-vitest-coverage` artifact. No API `tsc` build (Vitest runs TypeScript source; `lint.yml` runs `checktypes`).
+- **unit** — OpenAPI drift check (`pnpm generate && git diff --exit-code`), then `pnpm --filter @repo/api test:cov`. Uploads `api-vitest-coverage` artifact. No API `tsc` build (Vitest runs TypeScript source; `lint.yml` runs `checktypes`). Does not require `ANTHROPIC_API_KEY`; remote AI tests skip when the secret is absent.
 - **e2e** — Scalar login E2E via `test:e2e:local` (spawns API with `RATE_LIMIT_MAX=10000`; does not require `ANTHROPIC_API_KEY`).
 
 `cancel-in-progress: true`.

--- a/apps/docu/content/docs/deployment/github-actions.mdx
+++ b/apps/docu/content/docs/deployment/github-actions.mdx
@@ -18,7 +18,7 @@ Build → E2E. Triggers on pull request when `apps/web/**`, `apps/api/src/routes
 Two parallel jobs when `apps/api/**` or shared packages change:
 
 - **unit** — OpenAPI drift check (`pnpm generate && git diff --exit-code`), then `pnpm --filter @repo/api test:cov`. Uploads `api-vitest-coverage` artifact. No API `tsc` build (Vitest runs TypeScript source; `lint.yml` runs `checktypes`). Does not require `ANTHROPIC_API_KEY`; remote AI tests skip when the secret is absent.
-- **e2e** — Scalar login E2E via `test:e2e:local` (spawns API with `RATE_LIMIT_MAX=10000`; does not require `ANTHROPIC_API_KEY`).
+- **e2e** — Scalar login E2E via `test:e2e:local` (builds `@repo/api` deps, spawns API with `RATE_LIMIT_MAX=10000`; does not require `ANTHROPIC_API_KEY`).
 
 `cancel-in-progress: true`.
 

--- a/apps/docu/content/docs/deployment/github-actions.mdx
+++ b/apps/docu/content/docs/deployment/github-actions.mdx
@@ -11,11 +11,16 @@ Path filters are used only for test workflows (app E2E and package unit tests) s
 
 ### Web (`web-e2e.yml`)
 
-Build → E2E. Triggers on pull request when `apps/web/**`, `apps/api/src/routes/test/**`, shared packages, or openapi change. Single job: build (with localhost API URL), `test` (E2E-only placeholder, no unit suite), then E2E via `test:e2e:local` (spawns Fastify + Next with `ALLOW_TEST=true`, `RATE_LIMIT_MAX=10000`, and `WEBAUTHN_RP_NAME=Test App`).
+Build → E2E. Triggers on pull request when `apps/web/**`, `apps/api/src/routes/test/**`, shared packages, or openapi change. Single job: build (with localhost API URL), then E2E via `test:e2e:local` (spawns Fastify + Next with `ALLOW_TEST=true`, `RATE_LIMIT_MAX=10000`, and `WEBAUTHN_RP_NAME=Test App`). Requires `ANTHROPIC_API_KEY` for the chat E2E project. `cancel-in-progress: true`.
 
 ### API (`api-e2e.yml`)
 
-Build → Unit → E2E. Triggers on pull request when `apps/api/**` or shared packages change. Single job: build, unit tests, E2E via `test:e2e:local` (spawns API locally, runs Scalar login E2E).
+Two parallel jobs when `apps/api/**` or shared packages change:
+
+- **unit** — OpenAPI drift check (`pnpm generate && git diff --exit-code`), then `pnpm --filter @repo/api test:cov`. Uploads `api-vitest-coverage` artifact. No API `tsc` build (Vitest runs TypeScript source; `lint.yml` runs `checktypes`).
+- **e2e** — Scalar login E2E via `test:e2e:local` (spawns API with `RATE_LIMIT_MAX=10000`; does not require `ANTHROPIC_API_KEY`).
+
+`cancel-in-progress: true`.
 
 ### Packages (`packages-test.yml`)
 
@@ -23,7 +28,7 @@ Unit tests for shared packages (`core`, `react`, `error`, `utils`, …). Trigger
 
 ### API drift check (`api-e2e.yml`)
 
-When `apps/api/**` changes, CI runs `pnpm generate && git diff --exit-code` on `openapi.json` and `packages/core/src/gen` before build.
+When `apps/api/**` changes, the **unit** job runs `pnpm generate && git diff --exit-code` on `openapi.json` and `packages/core/src/gen` before Vitest.
 
 ### Docu (Vercel)
 
@@ -84,9 +89,10 @@ See the complete `.coderabbit.yaml` in the repository root for full configuratio
 
 ## Caching
 
-- **pnpm store** — all workflows cache `pnpm store path` keyed on `pnpm-lock.yaml`.
-- **Playwright** — `web-e2e` and `api-e2e` cache `~/.cache/ms-playwright`.
+- **pnpm** — `lint`, `packages-test`, `api-e2e`, `web-e2e`, and `security` use `.github/actions/setup-pnpm` (`actions/setup-node` with `cache: pnpm`).
+- **Playwright** — `web-e2e` and `api-e2e` **e2e** jobs cache `~/.cache/ms-playwright`.
 - **Next.js** — `web-e2e` caches `apps/web/.next/cache`.
+- **Turbo** — caches `build`, `checktypes`, and `lint:eslint`; **not** `test` / `test:unit` / `test:e2e`.
 - **Turbo remote cache** (optional) — set `TURBO_TOKEN` and `TURBO_TEAM` in GitHub Secrets after creating a Vercel Remote Cache token. Vercel deploys can reuse the same token. See [Development Tooling](/docs/development/dev-tooling#turbo-remote-cache-optional).
 
 ## Pre-commit Hooks

--- a/apps/docu/content/docs/development/dev-tooling.mdx
+++ b/apps/docu/content/docs/development/dev-tooling.mdx
@@ -12,7 +12,7 @@ pnpm lint
 pnpm lint:fix
 ```
 
-Turborepo caches `build`, `checktypes`, `lint:eslint`, and `test`. Per-package `build.env` in `turbo.json` hashes only vars that change emitted output (e.g. `VERCEL_GIT_COMMIT_REF` on `@repo/web#build` only). Consumer app builds no longer run OpenAPI codegen — use `pnpm generate` when API routes change. Commands: root README.
+Turborepo caches `build`, `checktypes`, and `lint:eslint`. `test`, `test:unit`, and `test:e2e` are not cached (`cache: false` in `turbo.json`). Per-package `build.env` in `turbo.json` hashes only vars that change emitted output (e.g. `VERCEL_GIT_COMMIT_REF` on `@repo/web#build` only). Consumer app builds no longer run OpenAPI codegen — use `pnpm generate` when API routes change. Commands: root README.
 
 ## Build performance
 

--- a/apps/docu/content/docs/testing/e2e-testing.mdx
+++ b/apps/docu/content/docs/testing/e2e-testing.mdx
@@ -41,7 +41,7 @@ test('shows dashboard when authenticated', async ({ page }) => {
 })
 ```
 
-Chat E2E needs `ANTHROPIC_API_KEY` (in-app Claude Haiku 4.5 by default). CI and web `test:e2e:local` set `AI_PROVIDER=anthropic` and verify the secret before E2E. API Scalar E2E (`apps/api test:e2e:local`) does not call AI and does not require Anthropic. Web chat (`chat-assistant.spec.ts`) skips on provider infra failures (402, upstream/5xx, network errors). API remote tests (`ai.spec.ts`) use `test/utils/ai-remote.ts`: skip 402 always; skip 502/503/504 only with placeholder/missing key — real key fails on 502. See [AI Architecture](/docs/architecture/ai).
+Chat E2E needs `ANTHROPIC_API_KEY` (in-app Claude Haiku 4.5 by default). CI and web `test:e2e:local` set `AI_PROVIDER=anthropic` and verify the secret before E2E. API Scalar E2E (`pnpm --filter @repo/api test:e2e:local`) does not call AI and does not require Anthropic. Web chat (`chat-assistant.spec.ts`) skips on provider infra failures (402, upstream/5xx, network errors). API remote tests (`ai.spec.ts`) use `test/utils/ai-remote.ts`: skip 402 always; skip 502/503/504 only with placeholder/missing key — real key fails on 502. See [AI Architecture](/docs/architecture/ai).
 
 ## Test helpers
 

--- a/apps/docu/content/docs/testing/e2e-testing.mdx
+++ b/apps/docu/content/docs/testing/e2e-testing.mdx
@@ -17,7 +17,7 @@ Root `pnpm qa` ends with `pnpm test:e2e` (`scripts/run-e2e.mjs`). That script ki
 | --- | --- |
 | `pnpm test:e2e` (root) | Fastify E2E, then Next E2E (spawns servers) |
 | `pnpm --filter @repo/web test:e2e:local` | Build (unless `SKIP_BUILD=1`), spawn API + Next, run web E2E |
-| `pnpm --filter @repo/api test:e2e:local` | Spawn API, run Scalar login E2E |
+| `pnpm --filter @repo/api test:e2e:local` | Spawn API (`RATE_LIMIT_MAX=10000`), run Scalar login E2E — no `ANTHROPIC_API_KEY` required |
 | `pnpm test:e2e:ui` / `test:e2e:debug` | Playwright UI or debug (in the app) |
 
 Pass URLs with `--app` / `--api`, or `PLAYWRIGHT_APP_URL` / `PLAYWRIGHT_API_URL`. Defaults: `http://localhost:3000` and `http://localhost:3001`.
@@ -41,7 +41,7 @@ test('shows dashboard when authenticated', async ({ page }) => {
 })
 ```
 
-Chat E2E needs `ANTHROPIC_API_KEY` (in-app Claude Haiku 4.5 by default). CI and `test:e2e:local` set `AI_PROVIDER=anthropic`. Web chat (`chat-assistant.spec.ts`) skips on provider infra failures (402, upstream/5xx, network errors). API remote tests (`ai.spec.ts`) use `test/utils/ai-remote.ts`: skip 402 always; skip 502/503/504 only with placeholder/missing key — real key fails on 502. See [AI Architecture](/docs/architecture/ai).
+Chat E2E needs `ANTHROPIC_API_KEY` (in-app Claude Haiku 4.5 by default). CI and web `test:e2e:local` set `AI_PROVIDER=anthropic` and verify the secret before E2E. API Scalar E2E (`apps/api test:e2e:local`) does not call AI and does not require Anthropic. Web chat (`chat-assistant.spec.ts`) skips on provider infra failures (402, upstream/5xx, network errors). API remote tests (`ai.spec.ts`) use `test/utils/ai-remote.ts`: skip 402 always; skip 502/503/504 only with placeholder/missing key — real key fails on 502. See [AI Architecture](/docs/architecture/ai).
 
 ## Test helpers
 

--- a/apps/docu/content/docs/testing/index.mdx
+++ b/apps/docu/content/docs/testing/index.mdx
@@ -37,12 +37,12 @@ Vitest `include` is `**/*.spec.ts` only. Every `*.test.ts` must be imported by a
 
 ## Coverage
 
-`pnpm --filter @repo/api test:cov` runs the same Vitest suite with v8 coverage (`apps/api/coverage/`). CI uploads the report from the api-e2e **unit** job. Playwright is not included. Known gaps (OAuth IdP exchange, skipped AI remote paths) stay uncovered. No coverage floors in CI yet.
+`pnpm --filter @repo/api test:cov` runs the same Vitest suite with v8 coverage (`apps/api/coverage/`). CI uploads the report from the api-e2e **unit** job. Playwright is not included. Known gaps (OAuth IdP exchange, skipped AI remote paths) stay uncovered. No coverage floors in CI yet. The unit job does not set `ANTHROPIC_API_KEY`; remote AI tests are skipped when the key is missing or placeholder.
 
 ## AI test split
 
 - **Contract (local, hard)** — `POST /ai/chat` and `/ai/generate` validation: 401 unauthenticated, 400 bad payloads, SSRF file-URL matrix (`data:` only). No provider calls; no soft skip.
-- **Remote (provider-dependent)** — Live Anthropic/Open Router/Ollama paths. Uses `ctx.skip()` via `test/utils/ai-remote.ts` on 402 credits or 502/503/504 when `ANTHROPIC_API_KEY` is missing or placeholder (`sk-ant-xxx`). With a real key, upstream failures fail the suite.
+- **Remote (provider-dependent)** — Live Anthropic/Open Router/Ollama paths. The remote `describe` blocks skip entirely when `ANTHROPIC_API_KEY` is missing or placeholder (`sk-ant-xxx`). With a real key, `test/utils/ai-remote.ts` skips on 402 credits; 502/503/504 fail the suite.
 
 Web chat E2E (`chat-assistant.spec.ts`) uses Playwright `test.skip` for provider outages — not SSRF coverage.
 

--- a/apps/docu/content/docs/testing/index.mdx
+++ b/apps/docu/content/docs/testing/index.mdx
@@ -35,6 +35,10 @@ HTTP errors use `{ code, message }` from the app catalog (`getError` / `sendCata
 
 Vitest `include` is `**/*.spec.ts` only. Every `*.test.ts` must be imported by a group entry `*.spec.ts` or it never runs.
 
+## Coverage
+
+`pnpm --filter @repo/api test:cov` runs the same Vitest suite with v8 coverage (`apps/api/coverage/`). CI uploads the report from the api-e2e **unit** job. Playwright is not included. Known gaps (OAuth IdP exchange, skipped AI remote paths) stay uncovered. No coverage floors in CI yet.
+
 ## AI test split
 
 - **Contract (local, hard)** — `POST /ai/chat` and `/ai/generate` validation: 401 unauthenticated, 400 bad payloads, SSRF file-URL matrix (`data:` only). No provider calls; no soft skip.

--- a/turbo.json
+++ b/turbo.json
@@ -196,6 +196,7 @@
     },
     "checktypes": { "env": ["NODE_ENV"] },
     "test": {
+      "cache": false,
       "env": [
         "NODE_ENV",
         "DATABASE_URL",
@@ -216,6 +217,7 @@
       ]
     },
     "@repo/web#test": {
+      "cache": false,
       "env": [
         "NODE_ENV",
         "DATABASE_URL",
@@ -236,6 +238,7 @@
       ]
     },
     "test:unit": {
+      "cache": false,
       "env": [
         "NODE_ENV",
         "DATABASE_URL",
@@ -259,6 +262,7 @@
       ]
     },
     "test:e2e": {
+      "cache": false,
       "env": [
         "NODE_ENV",
         "CI",


### PR DESCRIPTION
## Summary

- Split `api-e2e.yml` into parallel **unit** (OpenAPI drift + `test:cov` + coverage artifact) and **e2e** (Scalar Playwright) jobs; drop API `tsc` build from that workflow
- Add `.github/actions/setup-pnpm` composite and wire it into lint, packages-test, api-e2e, web-e2e, and security workflows
- Enable Vitest v8 coverage in `apps/api` and upload `api-vitest-coverage` artifact from CI
- Fix API Scalar spawn: `RATE_LIMIT_MAX=10000`, no `ANTHROPIC_API_KEY` requirement
- Set `cache: false` on Turbo test tasks; enable `cancel-in-progress` on api-e2e and web-e2e
- Remove placeholder `turbo run test` step from web-e2e

## Test plan

- [x] `pnpm qa` green locally (checktypes, lint, build, API Vitest, API Scalar E2E, web E2E)
- [ ] CI: api-e2e **unit** job passes without Playwright or Anthropic secret
- [ ] CI: api-e2e **e2e** job passes Scalar login E2E
- [ ] CI: `api-vitest-coverage` artifact uploaded from unit job
- [ ] CI: web-e2e unchanged behavior (chat still requires Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Blank or missing AI generation prompts now return a clear 400 error, even when no AI provider is configured.

- **Testing**
  - API unit tests now produce text, HTML, and LCOV coverage reports.
  - API and web end-to-end workflows run with improved cancellation and coverage artifact uploads.
  - AI-dependent tests skip when valid credentials are unavailable.
  - Test tasks no longer use Turbo caching.

- **Documentation**
  - Updated deployment, testing, and development guides for workflow, coverage, caching, and AI configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->