### PR TITLE
docs: add FIRST factory and basilic station instances

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate FIRST documentation
+        run: |
+          python3 _first/scripts/validate_docs.py
+          python3 -B _first/scripts/test_validate_docs.py
+
       - uses: ./.github/actions/setup-pnpm
 
       - name: Run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,6 @@ This repository uses **Cursor-native** AI workflows. Do not run a parallel proce
 - `.cursor/rules/` — constraints (override skills)
 - `.agents/skills/` — tech patterns (`<topic>-v<major>/`) and slash playbooks under `workflow/`; install/refresh via `pnpm dlx skills@latest add blockmatic/basilic-skills` (see [Cursor Skills](apps/docu/content/docs/development/cursor-skills.mdx)). Catalog: [`blockmatic/basilic-skills`](https://github.com/blockmatic/basilic-skills)
 - `apps/docu/content/docs/` — architecture, ADRs, how-to
+- FIRST: `_first/principles/X.md` then `_first/basilic/X.md` for the station in scope (`_first/AGENTS.md`, `_first/ABOUT.md`)
 
 Details: `apps/docu/content/docs/development/ai-workflow.mdx`.

--- a/_first/ABOUT.md
+++ b/_first/ABOUT.md
@@ -1,0 +1,108 @@
+# First Principles
+
+Version: 0.2-draft  
+Last reviewed: 2026-09-03
+
+Some decisions are too consequential to become afterthoughts. Important project knowledge should live in files, not disappear into conversations.
+
+This is an agent-first factory, not an agent-autonomous one. Humans still decide product scope, security-sensitive changes, and anything that cannot be recovered from the repository. Agents inspect, propose, implement, and update durable context. They do not silently invent the goal.
+
+"First" means: make the concern explicit before implementation, chat, or a generated UI invents it. The twelve are stations on one factory, not a waterfall and not competing religions.
+
+## Audiences
+
+- **Humans reading:** start at [README.md](README.md), then `articles/`.
+- **Agents operating:** start at [AGENTS.md](AGENTS.md), then this file, then `principles/`.
+- **Humans applying:** this file plus the matching `principles/X.md`. The essay is optional once you know the argument.
+
+Articles argue. Principles operate. Same filename in both folders.
+
+## Drop-in
+
+A repo can run the factory from three things:
+
+- `AGENTS.md`
+- `ABOUT.md` (this file)
+- `principles/`
+
+`README.md` and `articles/` are the human pack. They are not required for an agent to operate.
+
+## Documentation inventory
+
+The portable set has three entry-point documents and twelve one-to-one essay/spec pairs:
+
+| Path | Audience | Relationship |
+|---|---|---|
+| [README.md](README.md) | Humans | Front door and complete station index |
+| [AGENTS.md](AGENTS.md) | Agents | Load order, operating rules, and reusable prompt |
+| [ABOUT.md](ABOUT.md) | Both | Canonical map of audiences, loops, stations, and boundaries |
+| `articles/X.md` | Humans | Argument for station X; points to `principles/X.md` |
+| `principles/X.md` | Humans applying and agents operating | Operational spec for station X; points to `articles/X.md` |
+
+The canonical station order is Product → Journeys → Design → Architecture → Data → API → Documentation → Workflow → Pipelines → Quality → Security → Operations. The filenames are identical across `articles/` and `principles/`; the directory names distinguish argument from operation.
+
+## Lifecycle
+
+- **Draft** means the argument, sourcing, or boundary language may still change.
+- **Stable** means the essay and spec agree, precise claims and links were reviewed, and the documentation checks pass.
+- A version identifies the factory set. Project-specific decisions belong in the adopting repository, not in these generic files.
+
+This source set remains draft until its external references receive a publication review. `FEEDBACK.md` is an advisory review artifact, not part of the portable set.
+
+## Composing stations
+
+Choose one primary station for the decision being made. Load a secondary station only when the change crosses a boundary that station owns. Each station updates its own artifact; it may reference a sibling but does not duplicate the sibling's policy.
+
+Example: adding document export is Product for why the capability exists, Journeys for the user's completion and failure paths, Architecture for component and dependency changes, Data for ownership and retention of exported content, API for the contract, Security for who may export, and Quality for the release bar. One change can touch several stations without creating several sources of truth.
+
+## Loops
+
+**Inspect loop** — how an agent, or a human following a spec, applies a station to a repository:
+
+analyze → understand → take notes → identify gaps → propose → implement → validate → update project knowledge
+
+Inspect before generating. Preserve intentional existing decisions. Distinguish facts, reasonable inferences, assumptions, and unresolved questions. Ask a human only when consequential ambiguity cannot be resolved from the project.
+
+**Work loop** — how a change moves. It lives in Workflow First only:
+
+idea → plan → implement → review → pipeline signals → approval → release → learning
+
+Pipelines are the automated stretch of that loop. Do not keep a third loop in this file.
+
+## The twelve
+
+1. **Product** — what we are building, for whom, why it is worth building, and how we will know
+2. **Journeys** — how someone finishes a job, including errors, permissions, and state
+3. **Design** — how the product behaves and communicates through its interface
+4. **Architecture** — how the system is divided, depends, and deploys before local choices harden into structure
+5. **Data** — the canonical domain model, ownership, lifecycle, and evolution before stores proliferate competing truths
+6. **API** — the capability and its boundary, before consumers couple to an accident
+7. **Documentation** — which context must remain durable and discoverable
+8. **Workflow** — how work moves between humans, agents, tools, and decisions
+9. **Pipelines** — how a change reaches a validated, deployable state
+10. **Quality** — what "good" means before anyone optimizes toward an undefined target
+11. **Security** — what we are trusting, protecting, exposing, and allowing
+12. **Operations** — how we see, support, and recover the running system
+
+Event taxonomy is Product. Domain concepts, ownership, retention, and schema evolution are Data. External capability schemas are API. Eval datasets are Quality. Telemetry is Operations. Deployment topology is Architecture; deployment execution is Pipelines.
+
+## Boundaries
+
+Each station may point at a sibling in one sentence. It may not re-teach it.
+
+- **Product** owns what, why, how we will know, the event taxonomy, and GTM as a field. Not release bars, not error rates, not marketing automation.
+- **Journeys** owns what happens: actors, states, where permission gates occur, and completion. Security owns the permission policy. Not pixels. Not GTM acquisition maps.
+- **Design** owns how the interface expresses the job. Not the state model.
+- **Architecture** owns system decomposition, dependency direction, deployment topology, and structural tradeoffs. Not endpoint shape or runtime health.
+- **Data** owns canonical domain concepts, data ownership, lifecycle, retention, lineage, and schema evolution. Not product event goals or external contract shape.
+- **API** owns capability and contract shape, including how Security-owned authorization requirements and denials appear at the boundary. Not the authorization policy.
+- **Documentation** owns durable memory. Owns "chat is not the system of record" once.
+- **Workflow** owns actors, handoffs, issue/PR state, and human gates.
+- **Pipelines** owns the automated path, the commit-stage build, and readable failures. Not what "good" means.
+- **Quality** owns the release bar: tests, evals, budgets. Not funnels, not "CI ran."
+- **Security** owns trust, identities, authorization policy, secrets, classification, and the agent as a principal. Not contract shape.
+- **Operations** owns runtime health, recovery, and verify-in-the-running-system. Not product analytics.
+
+"Done" is always qualified. Quality: the bar was met. Product: observation after use. Pipelines: the bar actually ran.
+
+Human gates — product scope, security-sensitive changes, destructive operations — are Workflow and Security. The other stations point at them. They do not reprint them.

--- a/_first/AGENTS.md
+++ b/_first/AGENTS.md
@@ -1,0 +1,38 @@
+# Agents
+
+This directory is a portable product factory in markdown. Load it before inventing a parallel method.
+
+## Load order
+
+1. This file.
+2. [ABOUT.md](ABOUT.md) — map, loops, stations, boundaries, human gates.
+3. The target repository's own instructions and skills. They override generic FIRST guidance.
+4. `principles/X.md` for the primary station in scope. Load secondary specs only for boundaries the change actually crosses. Every spec has a same-named human essay in `articles/`.
+
+Do not treat `articles/` as required input. Essays argue. Specs operate. If a human asked for the argument, read the matching article after the spec, not instead of it.
+
+## Rules
+
+Inspect before generating. Preserve intentional existing decisions. Distinguish facts, reasonable inferences, assumptions, and unresolved questions.
+
+Propose the smallest useful change. Implement against the spec. Validate with the project's existing checks. Update durable project files when behavior or a decision changes.
+
+Stop and ask a human for:
+
+- product scope, priorities, success metrics, and go-to-market
+- security-sensitive changes, secrets, and trust-boundary edits
+- destructive operations (delete production data, force-push, drop a database, revoke access)
+
+Do not silently invent the goal. If the product bet is missing, say so.
+
+## Prompt
+
+Apply the matching principle to this repository.
+
+Name the primary station for the decision. Load another station only when the change crosses a boundary it owns; do not duplicate one station's policy in another station's artifact.
+
+Read ABOUT.md and `principles/X.md` before changing code or docs. Compare the spec to what the implementation actually does. Do not assume documentation is correct.
+
+Preserve intentional existing decisions. Do not widen scope into a public platform, a new methodology, or a second analytics stack unless the product already is that.
+
+When you change behavior that the spec names, update the durable artifacts in the same work.

--- a/_first/FEEDBACK.md
+++ b/_first/FEEDBACK.md
@@ -1,0 +1,45 @@
+# Documentation Review
+
+Reviewed: 2026-09-02  
+Resolution pass: 2026-09-03
+
+## Assessment
+
+FIRST has a strong core: a clear human/agent split, a memorable station model, consistent operational specs, and careful boundaries between neighboring concerns. “Articles argue; principles operate” gives the set a useful information architecture.
+
+The original review covered the 23-file, ten-station set. The resolution pass expands it to twelve stations and addresses the actionable structural findings. This file is an advisory review artifact, not another principle or part of the portable pack.
+
+## Resolution status
+
+| Finding | Status | Resolution |
+|---|---|---|
+| Canonical source was ignored under `__dev` | Addressed | The set now lives in `_first/`, which is visible to Git. It remains untracked until intentionally added and committed. |
+| API and Security both owned authorization | Resolved | Security owns policy; API represents and enforces the applicable requirement at the contract boundary; Journeys places the gate in the flow. |
+| Journeys required reviewers to find an unhandled state | Resolved | Validation now requires every mapped state to trace to implementation or an explicit deferral. |
+| Draft lifecycle was undefined | Resolved | `ABOUT.md` defines draft/stable semantics, version, and review date. |
+| Multi-station composition was unclear | Resolved | `ABOUT.md` and `AGENTS.md` define primary/secondary station routing with an example. |
+| Specs lacked a minimum artifact shape | Resolved | Every operational spec includes `Minimum Useful Artifact`. |
+| Documentation invariants were manual | Resolved | `scripts/validate_docs.py` checks files, pairs, headings, front matter, parity, order, cross-links, and local links. Seven regression tests protect the validator; the root lint workflow runs both. |
+| Installation and update behavior was implicit | Resolved | `README.md` documents the drop-in boundary, precedence, update behavior, and validation command. |
+| Essay set was uneven and repetitive | Improved | The longest essays received a focused redundancy pass; collection-wide editorial review remains part of stable publication. |
+| External claims and citations needed review | Link sweep complete; author review pending | All 46 unique external URLs were checked through direct retrieval or their primary-site index/search results. The Jeff Patton link was updated. The author's 2015 Continuous Delivery page appears in the blog index but could not be retrieved directly. Precise technical claims touched in this pass were checked; personal case-study claims still need author approval. |
+
+## Added principles
+
+### Architecture First
+
+Owns system decomposition, dependency direction, deployment topology, structural constraints, and decisions that are expensive to reverse. It does not own external contract shape, canonical data meaning, delivery automation, or runtime health.
+
+### Data First
+
+Owns canonical domain concepts, identity, authority, lifecycle, retention, lineage, invariants, and schema evolution. It does not own product event goals, external API representation, access policy, eval datasets, or operational telemetry.
+
+## Remaining release work
+
+1. Add and commit `_first/` so the new durable location has history and review.
+2. Confirm the 2015 Continuous Delivery page and approve the personal case-study claims and remaining historical interpretations for publication.
+3. Promote individual essays from `draft` to `stable` only after that review and a final collection-level edit.
+
+## Release bar
+
+The structural release bar now passes when `python3 scripts/validate_docs.py` succeeds. A stable editorial release additionally requires checked sources, intentional article status, and review of the collection as a whole.

--- a/_first/README.md
+++ b/_first/README.md
@@ -47,7 +47,7 @@ Copy `ABOUT.md` and `principles/` into the repository root. Do not copy other si
 
 The target repository's instructions override generic FIRST guidance. Adopt upstream FIRST changes deliberately by reviewing the diff rather than overwriting local instructions. The human pack—this README and `articles/`—is optional.
 
-Validate the complete source set with:
+Complete structural validation is for this source tree, not a drop-in copy. It needs `articles/` and `scripts/` in addition to `ABOUT.md` and `principles/`. From this directory:
 
 ```sh
 python3 scripts/validate_docs.py

--- a/_first/README.md
+++ b/_first/README.md
@@ -1,0 +1,61 @@
+# First Principles
+
+Some decisions are too consequential to become afterthoughts. This folder is a markdown factory for building software products with humans and agents in the loop.
+
+It is agent-first, not agent-autonomous. Humans still decide product scope, security-sensitive changes, and anything that cannot be recovered from the repository.
+
+## How to read this
+
+Start with the essays in `articles/`. Each one argues why a concern has to be named before implementation, chat, or a generated UI invents it. Essays are for humans. They do not contain an agent prompt.
+
+When you want to apply that concern to a real project, open the matching file in `principles/`. Same filename. The spec is the working recipe: artifacts, steps, validation, and — last — an agent prompt you can skip if you are doing the work yourself.
+
+The twelve are stations, not a waterfall and not competing religions. Read them in order the first time. After that, open the station the work is actually touching.
+
+A repo that only needs the factory can drop in `AGENTS.md`, `ABOUT.md`, and `principles/`. This README and `articles/` are the human pack.
+
+Same filename in both folders: `articles/API.md` argues; `principles/API.md` operates. Do not merge those jobs. Do not look for `articles/index.md` or a FIRST skill.
+
+When a station is in scope, read the essay for the argument, then the spec if you are going to apply it. An agent skips the essay unless a human asked for the argument.
+
+## The twelve
+
+Each station has a human essay and an operational spec. Read the essay to understand the argument; use the spec to do the work.
+
+| # | Station | Human essay | Operational spec | Owns |
+|---:|---|---|---|---|
+| 1 | Product | [Read](articles/PRODUCT.md) | [Apply](principles/PRODUCT.md) | What, why, audience, GTM, and how we will know |
+| 2 | Journeys | [Read](articles/JOURNEYS.md) | [Apply](principles/JOURNEYS.md) | Actors, states, permissions, errors, and completion |
+| 3 | Design | [Read](articles/DESIGN.md) | [Apply](principles/DESIGN.md) | How the interface behaves and communicates |
+| 4 | Architecture | [Read](articles/ARCHITECTURE.md) | [Apply](principles/ARCHITECTURE.md) | System boundaries, dependency direction, and deployment shape |
+| 5 | Data | [Read](articles/DATA.md) | [Apply](principles/DATA.md) | Canonical domain concepts, ownership, lifecycle, and evolution |
+| 6 | API | [Read](articles/API.md) | [Apply](principles/API.md) | Capability and contract boundaries |
+| 7 | Documentation | [Read](articles/DOCUMENTATION.md) | [Apply](principles/DOCUMENTATION.md) | Durable, accurate, discoverable context |
+| 8 | Workflow | [Read](articles/WORKFLOW.md) | [Apply](principles/WORKFLOW.md) | Actors, handoffs, work state, and human gates |
+| 9 | Pipelines | [Read](articles/PIPELINES.md) | [Apply](principles/PIPELINES.md) | Automated validation and delivery |
+| 10 | Quality | [Read](articles/QUALITY.md) | [Apply](principles/QUALITY.md) | Acceptance, tests, evals, and budgets |
+| 11 | Security | [Read](articles/SECURITY.md) | [Apply](principles/SECURITY.md) | Trust, authorization, secrets, and agent permissions |
+| 12 | Operations | [Read](articles/OPERATIONS.md) | [Apply](principles/OPERATIONS.md) | Runtime health, support, and recovery |
+
+The map of stations, loops, and boundaries is [ABOUT.md](ABOUT.md). That file is for both audiences. It is not another essay.
+
+This is not a methodology to install. It is not a waterfall. New stations need a distinctive decision they own; a shared theme or a new tool is not enough. Events remain Product, external contracts remain API, eval datasets remain Quality, telemetry remains Operations, and the commit-stage build remains Pipelines.
+
+## Using FIRST in another repository
+
+Copy `ABOUT.md` and `principles/` into the repository root. Do not copy other sibling directories in this tree. Use `AGENTS.md` as the starting template only when the target has no agent instructions; otherwise merge the FIRST load guidance into the existing instructions without overwriting them. Keep project-specific product decisions, architecture, and operating facts in that repository's own durable files; do not edit the generic specs to encode one project's choices.
+
+The target repository's instructions override generic FIRST guidance. Adopt upstream FIRST changes deliberately by reviewing the diff rather than overwriting local instructions. The human pack—this README and `articles/`—is optional.
+
+Validate the complete source set with:
+
+```sh
+python3 scripts/validate_docs.py
+python3 -B scripts/test_validate_docs.py
+```
+
+From the parent repository root, prefix each script path with `_first/`. The existing lint workflow runs both commands on pull requests. Structural validation is not a substitute for the publication review described in [ABOUT.md](ABOUT.md).
+
+## Agents
+
+If you are setting up a coding agent to apply this factory, start at [AGENTS.md](AGENTS.md). Essays are optional for the agent. Specs are not. Point the agent at the target repo's own skills. There is no FIRST skill file to install.

--- a/_first/articles/API.md
+++ b/_first/articles/API.md
@@ -42,7 +42,7 @@ I learned this on public HTTP, then on everything else. At Bitcash the matching 
 
 An API separates a useful capability from a particular interface.
 
-```
+```text
 capability
     ↓
 API / contract

--- a/_first/articles/API.md
+++ b/_first/articles/API.md
@@ -1,0 +1,126 @@
+---
+title: API First
+status: draft
+description: Define the capability and its boundary before consumers couple to an accidental implementation — including agent tools.
+---
+
+# API First
+
+## Principle
+
+Define the capability and its boundary before consumers couple to an accidental implementation.
+
+## The Case
+
+A product is a set of capabilities someone can use. An interface is one way to reach them.
+
+Those two facts get mixed up constantly. A team ships a screen. The handler behind it returns whatever was convenient that week. A mobile client copies the shape. A partner scripts against it. An agent wraps it as a tool. Nobody chose a boundary. The first consumer invented one, and everyone else inherited the accident.
+
+That is the product-development problem API First is trying to prevent. Not "we forgot the OpenAPI file." The more expensive failure is this: a useful capability becomes trapped inside the first interface that happened to call it.
+
+When the capability has an intentional boundary, the same work can be consumed by the web product, a mobile app, an internal system, a partner, a customer integration, an automation, an agent, or an interface that does not exist yet. The product can change how it is presented without rewriting what it does.
+
+SOAP already argued a version of this as contract-first versus code-first: write the WSDL, then implement, or generate the WSDL from whatever the class happened to expose. Spec-first is the grandchild of that fight. API First is not the same question. Spec-first asks whether the OpenAPI file existed before the handler. API First asks whether anyone chose the capability and the boundary before consumers coupled to whatever the code returned. Generating a spec from code can be fine if someone reviews that spec as a product decision. Hand-writing YAML is not the principle. Accidental coupling is.
+
+That is optionality. It is also a way to stay small. Guillermo Rauch has said that when he started angel investing, his thesis was that strong companies could begin as APIs. Scale AI was then scaleapi.com: an API in front of human labeling. Auth0 was identity behind a contract. Clearbit was business data behind a contract. In each case the interesting product move was not "we have REST." It was that a simple, stable interface could hide a large amount of real-world and business complexity, and that starting there helped founders focus instead of overbuilding a surface they did not yet understand.
+
+Stripe is the same pattern applied to payments. The hard part of charging money is banks, compliance, retries, and failure. The product bet was to make that complexity look like a library: named operations, predictable objects, errors a program can handle. Checkout pages and dashboards came after the capability was something another system could call.
+
+OpenAI is easy to misread here. The organization existed for years before it sold anything. Its first commercial product, announced in June 2020, was an API. That distinction matters. OpenAI did not "start API First" as a company origin story. It chose an API as the first way to turn a general-purpose model into something other people could build with.
+
+The announcement is still a clean product argument. Most AI systems were built for one use case. The API offered a general-purpose text-in, text-out interface. Developers could integrate it into products they already had, or invent products that did not exist yet. The surface was deliberately simple and flexible. The underlying models would keep changing; the product surface did not have to. That is what a good API does for a product: it lets the implementation move while the capability remains callable.
+
+Steve Yegge's retrospective account of Amazon's service-interface mandate illustrates the internal version: teams expose capabilities through interfaces instead of private back doors. Read it as an argument for callable boundaries, not as a complete explanation of AWS's history.
+
+Google Cloud draws a similar line between APIs designed for one-off integration and APIs designed for consumption. An integration API solves this week's connection. A consumption API assumes another developer will use it later, in a combination you did not plan. The second kind is slower to sketch and much cheaper over the life of a product.
+
+The same principle applies to a typed package interface, an event schema, a GraphQL schema, an RPC service, a CLI, an MCP tool, or an agent tool definition. The common idea is an intentional, composable boundary.
+
+I learned this on public HTTP, then on everything else. At Bitcash the matching engine, Hasura GraphQL APIs, and realtime indexer had to agree on what moved and who was allowed to move it. ChainGraph was a GraphQL subscription toolkit for streaming chain data: the query surface was the product for other developers, not an afterthought of the indexer internals. If the contract is implied by whatever the handler returned last Tuesday, you do not have an API. You have a leak.
+
+## Product Leverage
+
+An API separates a useful capability from a particular interface.
+
+```
+capability
+    ↓
+API / contract
+    ↓
+web · mobile · CLI · automation · agent · partner
+```
+
+That split changes what the product can do later.
+
+It creates optionality. You can add a client without cloning business logic. You can support a partner without forking the product. You can expose the same operation to an agent that will never see the screen. You can redesign the UI without pretending the capability moved.
+
+It speeds experimentation. A contract is a cheaper place to try a product idea than a fully built interface. Mocks and stubs let a team feel the shape of a flow before the implementation is real. More importantly, a stable capability lets you try new distribution — a CLI, a partner, an embed — without waiting to rebuild the core.
+
+It reduces accidental product coupling. When the web app talks to the database through whatever helper was nearby, the next interface inherits that helper's accidents: field names, error strings, auth checks that only exist on one route. When the capability has a boundary, product rules live once.
+
+It keeps product intent aligned with implementation. Product names the capability: charge a card, invite a member, retrieve case context. The API names how another system asks for that capability, what success and failure look like, and how the applicable authorization requirement is expressed. Security owns who is allowed to ask and what they may access. If you leave the boundary to the handler, the product is whatever shipped.
+
+It does not require every API to become a public developer platform. Postman's 2022 survey reported that 58 percent of the APIs respondents worked with were internal. The principle is not "open a marketplace." Important capabilities need intentional boundaries, including the ones only your own apps call.
+
+## Engineering Leverage
+
+An explicit contract is a stable boundary around a changing implementation.
+
+Frontend and backend can move in parallel against the same shape. That is the boring, repeatedly validated benefit in API-first engineering writing from Postman, Google Cloud, and everyone who has waited on a handler to exist before building a screen. The deeper version is not "two teams go faster." It is that neither side has to impersonate the other. The UI can be wrong about visual hierarchy and still be right about the operation. The service can change storage and still honor the same request.
+
+The boundary is what makes implementations replaceable. You can move from one framework, language, or datastore to another if consumers depend on the contract rather than the internals. Generated clients and types turn that contract into something compilers and agents can check. Contract tests catch drift while it is still a diff.
+
+Versioning, idempotency, consistent errors, and auth at the boundary are how a product survives retries, partial failure, and more than one consumer. Those are engineering concerns with product consequences. An error dialect per endpoint is not a style issue. It is a product that cannot be automated reliably.
+
+Composability follows. Small, intentional operations combine. Accidental god-handlers do not. Integration gets cheaper because the second consumer is not reverse-engineering the first.
+
+None of this requires a particular protocol. HTTP and OpenAPI are common because they are inspectable. A typed module in a monorepo is still an API. An event is an API with a clock. An MCP tool is an API with a name, a schema, permissions, and a failure mode. Treat them with the same seriousness.
+
+## In an Agentic System
+
+Agents can operate interfaces, but structured contracts reduce ambiguity and coupling to presentation.
+
+At Vercel Ship 2026, Ivan Zhao argued for designing structure and meaning before the interface because agents consume semantics and APIs. That is a useful design bias, not a literal claim that agents cannot see screens. Humans still need clear interfaces. A good tool for developers often serves agents well because both benefit from explicit capabilities.
+
+Rauch's later point is the same shift from the other side. Agents read Markdown, run CLIs, call MCP tools, and make API calls. Software becomes more invisible: computers talking to computers to get someone an answer. If you are starting now, he argues, focus on the API — and do it for the agents.
+
+Agent tools are APIs. A tool is a named capability with explicit inputs, outputs, permissions, and failure behavior. The [Model Context Protocol](https://modelcontextprotocol.io/specification/2026-07-28/server/tools) makes that literal: `name`, `description`, `inputSchema`, optional `outputSchema`, annotations. If you invent those shapes on the fly in a prompt, you have the same accident as an undocumented HTTP handler, except now a model is guessing.
+
+An intentional API therefore does two jobs at once. It is an architectural boundary between implementations. It is also a product surface for non-human consumers: scripts, partners, eval harnesses, coding agents, and in-product agents.
+
+That does not make the UI irrelevant. The strongest products expose the same underlying capabilities through multiple interfaces. The API is the shared trunk. Web, mobile, CLI, automation, agents, and partners are branches. If you only build the branch you can see, the next consumer has nothing to attach to.
+
+For coding agents working on the codebase, a contract is context they do not have to infer. They can inspect the spec, compare it to handlers and clients, and notice drift. They can generate types instead of inventing shapes. They can propose a contract change before coupling a second implementation. That only works if the boundary exists as an artifact, not as folklore in a handler.
+
+## What "First" Does Not Mean
+
+API First does not mean every product needs a public HTTP API.
+
+It does not mean finishing OpenAPI before a prototype can run. A private, unstable contract can live in code until a second consumer appears. The moment that consumer exists — another app, a test suite that freezes the shape, an agent tool, a partner — the accident starts. Write the boundary down then, or a little before.
+
+It does not mean designing for every future client. Optionality is not a permission to speculative-generality your way into abstraction soup. The smallest useful version is: name the capability, inputs, outputs, errors, applicable authorization requirement, and denial behavior. Security defines who may call; the API references and enforces that decision. The artifact can be a schema, typed function, or short spec. It does not have to be a platform program.
+
+It does not block internal refactors while the contract is still private. Change the implementation freely. Change the contract on purpose.
+
+It is not Product First. Product names the capability and why it exists. The API names how systems ask for it.
+
+It is not Documentation First. The contract is the artifact consumers and machines depend on. Documentation explains why it looks that way and how to use it. Both can live in the repo. They are not the same file.
+
+It is not Security First. Security owns who may invoke a capability and what they may access. API owns how that policy is represented and enforced at the contract boundary.
+
+It is not spec-first as a religion. Generating OpenAPI from code can be fine if the generated contract is reviewed as a product decision. Hand-writing YAML is not the principle. Accidental coupling is.
+
+## Spec
+
+Apply this: [principles/API.md](../principles/API.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Guillermo Rauch, "On APIs"](https://www.linkedin.com/pulse/apis-guillermo-rauch-aeupf) — companies that begin as APIs, complexity hidden behind a small surface, and why agents make that surface more important.
+- [OpenAI, "OpenAI API" (11 June 2020)](https://openai.com/index/openai-api/) — first commercial product as a general-purpose API; integrate into existing products or invent new ones; models change behind a simple interface.
+- [Vercel, "Vercel Ship 2026 recap"](https://vercel.com/blog/vercel-ship-2026-recap) — Ivan Zhao on designing API first and UI last because agents consume semantics, not screens. Read it as a split between human and machine interfaces, not as an argument that UI is finished.
+- [Postman, "What is API-first?"](https://www.postman.com/api-first/) — API-first as product and organizational strategy, distinct from design-first / spec-first; private APIs as most of the work.
+- [Google Cloud, "API design tips"](https://cloud.google.com/blog/products/api-management/google-cloud-api-design-tips) — APIs designed for consumption versus one-off integration.
+- [Steve Yegge, platform rant (2011)](https://gist.github.com/chitchcock/1281611) — reconstruction of Amazon's ~2002 service-interface mandate; design as if the interface could be external.
+- [Model Context Protocol, Tools](https://modelcontextprotocol.io/specification/2026-07-28/server/tools) — agent tools as named capabilities with schemas. The same principle, different transport.
+- [Best Practices for Designing RESTful APIs](https://gaboesquivel.com/blog/2015-10-best-practices-for-designing-web-apis) — earlier notes on HTTP contracts; narrower than this principle, still useful when the boundary is REST.

--- a/_first/articles/ARCHITECTURE.md
+++ b/_first/articles/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+---
+title: Architecture First
+status: draft
+description: Decide system boundaries, dependency direction, and deployment shape before local implementation choices harden into structural constraints.
+---
+
+# Architecture First
+
+## Principle
+
+Decide system boundaries, dependency direction, and deployment shape before local implementation choices harden into structural constraints.
+
+## The Case
+
+Every codebase acquires an architecture. The choice is whether its consequential structure is deliberate or merely the residue of whichever feature arrived first.
+
+A route imports a database client because it is convenient. A second application imports the route's private helper. A background job reaches into the same tables. Soon the dependency graph is the product architecture, but nobody chose it and nobody can explain which direction it is supposed to point. Local decisions became structural constraints one merge at a time.
+
+Architecture First is not a demand for a complete design before code. It is a demand to name the decisions that become expensive to reverse: responsibilities, process boundaries, shared state, external dependencies, deployment units, and the quality attributes that shape them. Those decisions deserve more scrutiny than a replaceable framework detail.
+
+The useful architectural map is smaller than most architecture decks. A system context shows people and external systems. A container view shows applications and data stores. A deployment view shows what actually runs where. The [C4 model](https://c4model.com/) is useful because it separates these levels and recommends using only the views that add value. The model is not the principle. The principle is that a future contributor should not need to infer the system boundary from imports and cloud consoles.
+
+Decision records solve a related problem. A diagram shows what exists; an ADR records why a consequential choice was made, which alternatives mattered, and what consequences were accepted. The record is valuable when a new constraint appears and the team needs to know whether to preserve or supersede the old choice.
+
+Agents make accidental architecture cheaper to produce. They can add a service, abstraction, queue, or shared package quickly. Without a structural model, they optimize the local task and distribute its consequences across the repository. A written boundary gives them something stronger than proximity to follow.
+
+## Product Leverage
+
+Architecture preserves product options. A capability placed behind a clear boundary can gain another interface. A tightly coupled workflow cannot change channel without moving half the system.
+
+It also exposes product cost. A request for instant consistency across regions, offline operation, or regulated isolation is not a neutral requirement. It shapes stores, deployment, failure modes, and team ownership. Making the structural consequence visible lets the product decide whether the value justifies it.
+
+Time to market benefits from proportional architecture. The point is not to create more parts. It is to avoid creating the wrong irreversible part. A modular monolith with a clear dependency direction is often more useful than services whose boundaries were copied from an organization chart.
+
+Architecture is also where build-versus-buy becomes concrete. A managed service trades implementation work for dependency, cost, and exit constraints. A homegrown subsystem makes the reverse trade. Recording the choice prevents a vendor or framework from becoming an unexplained product constraint.
+
+## Engineering Leverage
+
+Clear boundaries make change local. If dependencies point toward stable domain capabilities rather than outward toward delivery details, replacing a UI, datastore, or vendor does not require rewriting every caller.
+
+Architecture also makes review possible. “This adds a dependency from the domain to the web framework” is a reviewable statement. “This feels too coupled” is not. Dependency rules can sometimes be enforced with package boundaries, import checks, or build configuration. The diagram and ADR explain the intent; code and checks protect it.
+
+Deployment shape belongs here because process boundaries change failure. An in-process call and a network call can expose the same API while having different latency, availability, retry, and observability needs. Pipelines deliver the units. Operations runs them. Architecture decides that the units exist and explains the trade.
+
+The architecture model must follow reality. A pristine diagram that omits the queue, shared database, or manual batch job is worse than a rough diagram that shows the actual plant.
+
+## In an Agentic System
+
+Agents are strong local optimizers. Architecture is the durable context that keeps local optimization from becoming global disorder.
+
+An agent should inspect repository structure, deployment configuration, data stores, and runtime entry points before proposing a new component. It should preserve intentional boundaries and ask what existing part owns the responsibility. It should not infer that every capability needs a service or that every repeated line needs a shared framework.
+
+For in-product agents, architecture names the agent as a runtime component: where it executes, which tools it can call, what state it reads, and what happens when it retries or fails. API owns each tool contract. Security owns permission policy. Operations owns visibility and recovery. Architecture makes their relationship legible.
+
+The smallest architecture artifact gives the agent a map: the system, its users, external systems, deployable units, stores, and labeled dependencies. That is enough to challenge a change that points the wrong way.
+
+## What "First" Does Not Mean
+
+Architecture First is not Big Design Up Front. It does not mean predicting every future requirement or drawing every class.
+
+It is not a license for speculative layers, services, event buses, or platforms. If one process and one database meet the product's constraints, that can be the deliberate architecture.
+
+It is not API First. Architecture decides which parts communicate and where responsibility lives. API defines the contract across a boundary.
+
+It is not Data First. Architecture places stores and data flows. Data defines the canonical meaning, authority, lifecycle, and evolution of the state they carry.
+
+It is not Documentation First. Architecture owns structural decisions. Documentation ensures the context remains durable and discoverable.
+
+The smallest useful version is one accurate context or container diagram plus a short decision record for the choice that would be painful to reverse.
+
+## Spec
+
+Apply this: [principles/ARCHITECTURE.md](../principles/ARCHITECTURE.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [The C4 model](https://c4model.com/) — hierarchical, notation-independent views of software systems, containers, components, and deployment.
+- [C4 system context diagram](https://c4model.com/diagrams/system-context) — the smallest recommended view of people, the system, and external dependencies.
+- [Martin Fowler, "Architecture Decision Record"](https://martinfowler.com/bliki/ArchitectureDecisionRecord.html) — short records of context, decision, rationale, and consequences.
+- [Martin Fowler, "Who Needs an Architect?"](https://martinfowler.com/ieeeSoftware/whoNeedsArchitect.pdf) — architecture as the important, hard-to-change decisions a team needs to understand.

--- a/_first/articles/DATA.md
+++ b/_first/articles/DATA.md
@@ -1,0 +1,86 @@
+---
+title: Data First
+status: draft
+description: Define canonical domain concepts, ownership, lifecycle, and change rules before stores, schemas, and events proliferate competing truths.
+---
+
+# Data First
+
+## Principle
+
+Define canonical domain concepts, ownership, lifecycle, and change rules before stores, schemas, and events proliferate competing truths.
+
+## The Case
+
+Features leave data behind. That state usually outlives the screen, route, service, and team that created it.
+
+A customer exists in the application database, billing provider, CRM, analytics warehouse, and support tool. Each copy has a different identifier and a slightly different meaning of “active.” A field is renamed in one store and repurposed in another. Deletion removes the account but not the export. Nobody intended five truths. Each consumer made the locally convenient choice.
+
+Data First names the decisions that keep representations from becoming competing realities: what a concept means, how it is identified, which source is authoritative, who owns it, which invariants must hold, how copies are derived, how the schema evolves, and when the data is retained or deleted.
+
+This is not “choose a database first.” Storage technology is an architectural and implementation choice. The product needs a stable concept before it needs a table. A domain model can be a short glossary and a few relationships. The goal is shared meaning, not a diagramming ceremony.
+
+Eric Evans's domain-driven design calls this a ubiquitous language: use the model in conversation and code so that translation does not quietly change the product. The useful part here is narrower than adopting all of DDD. Name the core concepts and their boundaries. Do not let `customer`, `account`, `member`, and `user` become synonyms by accident.
+
+Integrity belongs as close to the data as practical. Types, unique keys, foreign keys, and check constraints prevent invalid states regardless of which caller writes them. Application validation still matters, especially for rules that cross context or time. The point is to choose where the invariant lives instead of hoping every writer remembers it.
+
+Schema change is product change when durable meaning moves. Adding a nullable field may be easy. Splitting one identity into two, changing money units, or deleting historical records is not. Migrations need compatibility, backfill, rollback or recovery, and an explicit statement of what the old data becomes.
+
+Agents amplify both sides. They can trace schemas and write migrations quickly. They can also create a new table, event, cache, or vector store without noticing that the concept already has an owner. A durable data map keeps speed from multiplying sources of truth.
+
+## Product Leverage
+
+Consistent data keeps the product from contradicting itself. If billing says a subscription is active while the application says it is canceled, the user experiences the weaker model, not the better schema.
+
+Identity is product behavior. Merging accounts, inviting a member, exporting a case, or deleting a workspace all depend on what the system believes is the same entity. An unstable identity rule becomes duplicate notifications, missing history, or access granted to the wrong record.
+
+Lifecycle is also part of trust. Retention can support recovery, audit, and learning. It can also preserve data the product no longer has a reason to hold. Product states the need; Security sets protection and policy; Data makes the lifecycle and implementation visible.
+
+Analytics depends on the same foundation without owning it. Product names the event and metric. Data makes clear what entity the event refers to, which identifier is stable, and how derived tables relate to the source. A funnel built on ambiguous identity is a precise chart of an unclear product.
+
+## Engineering Leverage
+
+A canonical model reduces translation code. Services and interfaces can have representations suited to their consumers, but those representations map to one understood domain rather than inventing meaning independently.
+
+Ownership makes incidents and changes routable. When a dataset has an authoritative source and owner, a stale copy has somewhere to reconcile. Without ownership, every correction is a negotiation between equal-looking tables.
+
+Constraints turn assumptions into executable rules. A uniqueness requirement written only in a prompt can be violated by the next import. A constraint, test, or migration check can fail loudly.
+
+Lineage makes derived data explainable. The warehouse, search index, cache, and embedding store may all be legitimate copies. Each needs a path back to authority, a refresh or invalidation rule, and a deletion story. “Eventually consistent” is not a lifecycle plan unless someone can say eventually by what mechanism.
+
+Evolution deserves the same care as creation. Expand-and-contract migrations, versioned events, dual reads, and backfills are tools. The principle is that old and new representations coexist deliberately for a bounded period instead of becoming permanent parallel truths.
+
+## In an Agentic System
+
+Agents need canonical nouns. If two schemas use `case_id` differently, an agent will choose from proximity, naming, or examples. That is inference where the project needed a decision.
+
+A coding agent should trace writes and reads before creating state. It should inspect migrations, events, analytics models, caches, and external sources—not only the primary ORM model. It should identify the owner and lifecycle before introducing another copy.
+
+In-product agents create new data concerns: conversation history, retrieved context, tool results, embeddings, evaluations, and traces. Some are product state, some are quality datasets, and some are operational telemetry. Naming the owner prevents a debug log from quietly becoming a permanent customer record.
+
+The agent may propose a model or migration. A human still decides consequential retention, deletion, residency, or product-meaning changes. Data First makes those gates visible before a generated migration runs.
+
+## What "First" Does Not Mean
+
+Data First does not mean buying a warehouse, adopting data mesh, or designing an enterprise ontology for a small application.
+
+It does not mean every representation must be identical. API payloads, relational schemas, search documents, and analytics tables serve different jobs. They need explicit mappings and authority, not one physical format.
+
+It is not Product First. Product owns outcomes, metrics, and event taxonomy. Data owns the meaning, authority, and lifecycle of the records.
+
+It is not API First. API owns the external contract and compatibility promise. Data owns the canonical domain concepts behind it.
+
+It is not Security First. Security owns access and protection policy. Data records classification, retention, deletion, and where copies exist so that policy can be enforced.
+
+The smallest useful version is one domain concept with a definition, stable identity, authoritative source, owner, invariants, readers and writers, and deletion rule.
+
+## Spec
+
+Apply this: [principles/DATA.md](../principles/DATA.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Eric Evans, *Domain-Driven Design Reference*](https://www.domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf) — putting a shared domain model and language to work.
+- [Martin Kleppmann, *Designing Data-Intensive Applications*](https://martin.kleppmann.com/) — durable reasoning about data models, storage, replication, consistency, and evolution.
+- [PostgreSQL, "Constraints"](https://www.postgresql.org/docs/current/ddl-constraints.html) — executable integrity through not-null, unique, primary-key, foreign-key, check, and exclusion constraints.
+- [Martin Fowler, "Data Mesh Principles and Logical Architecture"](https://martinfowler.com/articles/data-mesh-principles.html) — domain-oriented ownership and data as a product at organizational scale; useful when the scale justifies it, not a default architecture.

--- a/_first/articles/DESIGN.md
+++ b/_first/articles/DESIGN.md
@@ -1,0 +1,98 @@
+---
+title: Design First
+status: draft
+description: Decide how the product behaves and communicates through its interface before layout and components become accidental consequences of implementation.
+---
+
+# Design First
+
+## Principle
+
+Decide how the product behaves and communicates through its interface before layout and components become accidental consequences of implementation.
+
+## The Case
+
+Useful software is the floor. The product people remember is the one that feels clear, thoughtful, and enjoyable to use.
+
+Design here is not decoration bolted on at the end. It is behavior, hierarchy, states, copy, and motion. Before a new pattern exists, the project already has tokens, primitives, components, and conventions — or it is about to invent a second product language by accident.
+
+Without design intent, every screen invents its own patterns. Buttons almost match. Loading, empty, and error states ship as afterthoughts. Accessibility becomes a retrofit. Agents generate UI that works and does not belong to the same product.
+
+Later never has the same leverage. Once components multiply, you are migrating a visual language instead of composing one. A design system — tokens, primitives, composition rules, content patterns — is how a team, including agents, stays inside one product.
+
+That system has to be readable. Mobile-first, atomic design, and the last decade of design-system writing already argued for shared parts. The agentic delta is that a Figma file the agent cannot open is folklore. A bag of hex values with no rules is a theme, not a language: you cannot say "primary is only for the main CTA" in a color map.
+
+`DESIGN.md` is one way to write that language down so an agent can follow it. OpenAPI is the sibling move for APIs. Neither file is the principle. Design-system-file-first asks whether we dropped a YAML file in the root. Design First asks whether the interface language — values, states, copy, motion, and what not to invent — was defined before implementation composed a second product. A file that only lists hex codes is a theme. The interesting part is the body: when primary is allowed, what empty looks like, what a screen must never mix.
+
+Joshua Porter's point about empty states is still the right instinct: the first screen a person sees teaches them how the software works. A blank table is a product decision. Nielsen Norman's later guidance is the same: an empty panel that does not explain whether the system is loading, empty, or broken is missing communication. Microcopy is part of that communication. If engineers invent that text per screen, the product speaks in several voices.
+
+Delight is not fluff. A press state that lands, a toast that arrives fast, a skeleton that holds layout, an empty state that tells you what to do next — those are how the interface talks. Keep them fast. Respect reduced motion.
+
+On LegalAgent the assistant is voice and chat. The design job is how that conversation is expressed: hierarchy, turn-taking, empty, error, what the retrieval looks like when it fails. The admin path is a different journey. Do not collapse them into one layout problem.
+
+Refero and similar galleries are research. They are not the system. Generated UI currently clusters around a few looks regardless of product. A readable system that is about this product is how you refuse the default collage.
+
+## Product Leverage
+
+Design First is a product-quality argument.
+
+It is how the product feels like one product across screens, platforms, and releases. Consistency is not brand vanity. It is reduced cognitive load. People should not have to relearn confirm, cancel, and error every time they move.
+
+It is how customer experience survives the unhappy path. Loading, empty, error, success, and disabled are most of real use. If you only design the populated happy view, you designed a screenshot.
+
+Tokens and primitives are product optionality: a new density, a new theme, a new surface can reuse behavior. A pile of one-off layouts cannot.
+
+Interaction quality is a distribution issue. An interface that is unclear does not get a second session. Contrast that fails WCAG is the same class of problem: people who cannot read the button cannot use the product. A green token lint is not an accessible interface.
+
+## Engineering Leverage
+
+A design system is an interface contract for UI, the way an API is a contract for capabilities.
+
+Reuse beats invention: tokens, primitives, composition. New components are exceptions with a written reason. That is a smaller surface for agents to hallucinate against.
+
+The implementation still has to hold the contract: component library, CSS variables, theme. Two palettes is the visual version of spec/implementation drift. Pick a source of truth and export the rest.
+
+States defined up front are testable. You can validate loading and error in a browser instead of discovering them in production. Accessibility — focus, labels, contrast, keyboard, reduced motion — is cheaper as a constraint than as a retrofit.
+
+Motion with a rule (fast feedback, not decoration; honor `prefers-reduced-motion`) keeps the implementation from becoming a second animation library per feature.
+
+Independent evolution of screens only works if they compose from the same parts. Tooling details — lint, DTCG export, Stitch — live in the spec.
+
+## In an Agentic System
+
+Coding agents are fluent at generating UI and poor at belonging to an existing product.
+
+Without a system to read, they will invent a third button, a new spacing scale, and a unique empty state. "Reuse these primitives" is a constraint an agent can follow. "Make it look nice" is not.
+
+A file the agent is not told to read is as invisible as a Figma link. Point the project's agent instructions at the design contract.
+
+Validation has to be in the browser, across states. A screenshot of the default view is not verification. Contrast lint is not verification. That bar has to be explicit.
+
+Do not treat "AI will generate the UI" as a reason to skip the system. Generation without a system produces collage at scale. Generation against a contract with no don'ts produces a consistent collage.
+
+Zhao's structure-and-meaning-first claim in the API essay is the sibling. Design First is how the human-visible expression of that structure stays considered.
+
+## What "First" Does Not Mean
+
+Design First is not visual polish only. It does not require a designer on every task. It does not mean blocking a ship until every pixel is perfect.
+
+It does not mean DESIGN.md-first as a ceremony. You do not owe anyone a YAML schema before a prototype can have a button. If the project already has tokens in a theme or a component library, describe that system rather than inventing a second brand.
+
+It does not mean a file instead of a library. Hex codes in markdown do not stop a one-off `div`.
+
+It does not replace Journeys First. The flow defines what happens. Design defines how that behavior is expressed. You can map a complete path and still ship an accidental UI.
+
+It is not Documentation First. The design contract is not the project's memory. Both can live in the root. They are not the same file.
+
+The smallest useful version: list the states the feature needs, pick primitives from the system, write the interaction in a paragraph, check accessibility, look at it in a browser.
+
+## Spec
+
+Apply this: [principles/DESIGN.md](../principles/DESIGN.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Joshua Porter, "Writing Microcopy"](https://bokardo.com/archives/writing-microcopy/) — small functional text that gets someone through a moment; empty, error, and confirm copy are product decisions.
+- [Nielsen Norman Group, "Designing Empty States in Complex Applications"](https://www.nngroup.com/articles/empty-state-interface-design/) — loading versus empty versus error as communication, not illustration.
+- [google-labs-code/design.md](https://github.com/google-labs-code/design.md) — one artifact for an agent-readable identity. Currently `alpha`. Not the principle.
+- [W3C Design Tokens](https://www.designtokens.org/) — typed token groups and interchange.

--- a/_first/articles/DOCUMENTATION.md
+++ b/_first/articles/DOCUMENTATION.md
@@ -1,0 +1,91 @@
+---
+title: Documentation First
+status: draft
+description: Keep the context future humans and agents need to decide well in durable project files, not in conversations that disappear.
+---
+
+# Documentation First
+
+## Principle
+
+Keep the context future humans and agents need to decide well in durable project files, not in conversations that disappear.
+
+## The Case
+
+I document decisions and context, not obvious code. If someone will need to rediscover it, explain it twice, or guess why we chose this, it belongs in a file.
+
+Architecture, conventions, setup, constraints, domain knowledge, agent instructions — these are load-bearing. Documentation is not a deliverable for its own sake. It is how a project stays intelligible when the people and the chat sessions move on.
+
+Undocumented decisions become folklore. New contributors reconstruct context from code and guess wrong. Agents do the same, faster. Docs that drifted from reality are worse than no docs: they are a confident lie. When implementation changes behavior and nobody updates the file, the next session starts from the old story.
+
+Tom Preston-Werner's README Driven Development is the ancestor of the factory's own doors. Write the human intro before the implementation invents the story. This factory splits that instinct: `README.md` is the human door, `ABOUT.md` is the factory map. Neither replaces an ADR. Both exist so the next reader does not start from chat.
+
+Michael Nygard's Architecture Decision Records were a reaction to the same loss. A short text file in the repo: context, decision, consequences. Not a wiki nobody owns. Martin Fowler later called Nygard's original essay better than almost everything written after it. The format is not the principle. The principle is that architecturally significant choices should not live only in the heads of the people who were in the room.
+
+The agentic delta is simple. Agents have no memory except files, skills, and the current context window. Chat is not the system of record. If the project's conventions, architecture, and constraints are not in the repo, the agent will infer them from code — including the accidents. This factory is that rule applied to itself: the essays argue, the specs operate, ABOUT maps the plant. None of that works if the next session has to reconstruct it from a transcript.
+
+Volume is not success. Drift is failure. A short ADR that is true beats a long guide that was true last quarter.
+
+The customer-facing version of the same rule has a different audience: the explanations people need to use the product should not live only in support tickets. This station is still the project's memory. Help centers and API docs are related. They are not a substitute for the decision that must survive the next context window.
+
+`llms.txt` belongs in that public-documentation layer. It is a selective, machine-readable orientation to website content so an agent can find useful pages without reconstructing the site from rendered HTML. It is not a permission file, a crawler-control file, or a substitute for `AGENTS.md`. The public docs own it. Repository agent instructions mention it only when maintaining or validating it is part of the work.
+
+## Product Leverage
+
+Documentation sounds like engineering hygiene. The product cost of skipping it is real.
+
+A product team that cannot explain why a constraint exists will violate it. Regulated finance, data residency, a non-goal, a permission model: those are product facts. If they only live in Slack, the next feature will contradict them and ship. A forgotten constraint is a shipped bug with a planning costume. The engineer who was in the room is not a backup disk. Neither is the agent that was in the last session.
+
+Onboarding speed is time to market. A new engineer or a new agent that can set up and orient from files starts contributing to the actual product instead of reconstructing it.
+
+Documentation also preserves optionality. The reason you did not build a marketplace, the reason the API is private, the reason the agent cannot delete production data — those decisions are how you keep the ability to change the product on purpose. Forgotten decisions get re-litigated as if they were open, or reversed by accident.
+
+## Engineering Leverage
+
+Clear code still wins. Comments that restate the next line are noise.
+
+What does not belong only in code is the choice you would otherwise debate again: why this boundary, why this constraint, why this is out of scope, how to run the thing, what an agent is allowed to assume.
+
+ADRs, architecture notes, conventions, and agent instructions reduce coupling to individuals. They make parallel work possible because people are not blocked on asking. They make replaceable implementations possible because the intended boundary is written down.
+
+They also make drift visible. A spec and an implementation can disagree in a diff. Folklore cannot.
+
+Docs-as-code is the delivery mechanism, not the principle. Markdown in the repo diffs. A generated site is fine if the source of truth is still a file someone can correct in the same change as the behavior. A wiki nobody owns is how the next session inherits a lie.
+
+## In an Agentic System
+
+Chat is a terrible system of record for an actor that starts every session empty.
+
+Agent instructions, skills, and ADRs are how you give an agent a project it can actually read. Updating those files when behavior changes is how you stop the next session from "correcting" the product back to an old README.
+
+Delegation is easier when the agent can be told "read these files first" instead of receiving a recap of the company. Validation is easier when the agent is required to update the durable context in the same change.
+
+Human approval still belongs on the decisions themselves. Documentation First is about recording them, not about letting the agent invent them.
+
+## What "First" Does Not Mean
+
+Documentation First is not commenting every function. It is not writing before thinking. A paragraph in an ADR is better than a page of speculation.
+
+It does not replace Workflow First. Workflow is when context is created, handed off, and reviewed. Documentation is what you keep after the handoff so the next actor does not start from zero.
+
+It is not a license to generate docs because a template has a section for them. If there is no future reader, do not write it.
+
+It does not mean every site needs `llms.txt`. Add it when public documentation is substantial enough that selective machine-readable orientation helps, and generate it from canonical content where practical rather than creating another hand-maintained truth.
+
+The smallest useful version: one README that can get someone running, one place for conventions, ADRs only for decisions that will still matter, agent instructions that match the repo. Delete or archive what is wrong. Wrong docs are harmful.
+
+If the answer to "why did we do it this way?" is "it was in chat," the factory already lost. Write the decision. Then the next human, and the next agent, can disagree with a file instead of a ghost.
+
+The factory's own files are the proof. ABOUT, AGENTS, and the specs only work if they stay true. That is Documentation First applied at home, not a metaphor.
+
+## Spec
+
+Apply this: [principles/DOCUMENTATION.md](../principles/DOCUMENTATION.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Tom Preston-Werner, "Readme Driven Development"](https://tom.preston-werner.com/2010/08/23/readme-driven-development.html) — write the human intro before the implementation invents the story.
+- [Michael Nygard, "Documenting Architecture Decisions" (2011)](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions) — the original ADR: short, in the repo, context / decision / consequences.
+- [Martin Fowler, "Architecture Decision Record"](https://martinfowler.com/bliki/ArchitectureDecisionRecord.html) — why Nygard's form stuck, and what not to inflate it into.
+- [Architecture Decision Records](https://gaboesquivel.com/blog/2024-07-adrs-in-software-teams) — using ADRs in actual teams.
+- [The `llms.txt` proposal](https://llmstxt.org/) — selective, path-scoped orientation for agents using website documentation; complementary to human navigation and sitemaps.

--- a/_first/articles/JOURNEYS.md
+++ b/_first/articles/JOURNEYS.md
@@ -1,0 +1,93 @@
+---
+title: Journeys First
+status: draft
+description: Map how someone finishes a job — including errors, permissions, and state — before implementation invents the path from the first screen.
+---
+
+# Journeys First
+
+## Principle
+
+Map how someone finishes a job — including errors, permissions, and state — before implementation invents the path from whichever screen shipped first.
+
+## The Case
+
+The product is not a collection of screens. It is someone trying to finish a job.
+
+Happy paths are easy to ship. Products fail in the gaps: the session that cannot be recovered, the error with no next step, the permission that exists on one route and vanishes on the API that route calls. Those missing states do not stay missing. They show up in support, in production, and in the next feature that assumes a complete model.
+
+The implementation did not just skip an edge case. It decided, by omission, what the product does when things go wrong.
+
+Jeff Patton's user story mapping exists because flat backlogs hide that picture. A list of features does not tell you whether a person can get through the job. Mapping left to right as a narrative, then slicing a walking skeleton, is how you notice the hole before you build muscle on one step. This principle is not "adopt story mapping." It is the same insistence: see the whole job before the routes harden.
+
+Jobs-to-be-done makes the same point from the customer's side. People hire a product to make progress in a circumstance. If you design screens instead of the job, you optimize the wrong thing. Journeys First is how that job becomes an engineering input: actor, entry, states, failure, permission, completion.
+
+Marketing "customer journey" maps are a cousin with a different job. Those charts are acquisition and GTM. They live with Product when they matter. This station is how someone finishes a job in the product, including the operator who never appears in a funnel.
+
+For LegalAgent I built the Expo assistant — voice, chat, retrieval for case context — and the TanStack Start admin that lets the team control documents, prompts, and retrieval categories. Those are not two UIs. They are two paths through the same product: a lawyer finishing a job in the assistant, and an operator keeping the sources and instructions correct. If you only design the chat, you miss who is allowed to change what the model sees. If you only design the admin, you miss where the assistant fails and how someone recovers. The flow has to include both actors, both entry points, and the permission gate between them.
+
+Agents implement the flow they can see and invent the rest. If the rest is not written down, the invention becomes the product. In-product agents are actors in the same map. An unnamed actor gets invented tools.
+
+How that plot looks on screen is Design. Do not retell the state model as a layout problem, and do not let a polished empty state stand in for a missing recovery path. A journey shows where a permission gate occurs and what the actor experiences; Security defines who is allowed through it.
+
+## Product Leverage
+
+A mapped journey is how you stop shipping a pile of screens that do not add up to a finished job.
+
+It improves customer experience in the places people actually abandon you: errors, permissions, resume, cancel. Empty and failure states are not design polish. They are whether the product still works when reality shows up.
+
+It reduces coupling between surfaces. The same job on web and mobile should not have different permission rules because two routes were built months apart. The journey is the shared plot. How the interface expresses that plot is Design.
+
+It makes experiments cheaper. A walking skeleton — Patton's thinnest slice that still crosses the whole job — is a product you can learn from. A vertical slice of one gorgeous step is a demo.
+
+"Lawyers" and "operators" are not personas on a slide. They are actors with different entries, different permissions, and different completion criteria. Mixing them in one undifferentiated flow is how you ship an admin control into a customer path, or leave a customer stuck with no recovery.
+
+Time to market improves when you stop discovering the real flow in QA. You still ship a thin path. You ship it on purpose, with named holes.
+
+A walking skeleton that includes one error and one permission gate teaches more than a polished happy path. The missing states are the product. Write them before the routes pretend they do not exist.
+
+## Engineering Leverage
+
+A journey gives engineering a state model before the code invents one.
+
+Entry points, permissions, and error recovery are implementation work. If they are not named, they land inconsistently: a check in the UI, a different check in the API, none in the job the agent runs. The failure mode is not "missing a test." It is two implementations of the same product rule.
+
+Acceptance criteria can be traced to completion of the job, not to whichever route was convenient. That makes Quality attach to something real. It also makes API First less likely to encode an incomplete flow as a resource that cannot represent failure.
+
+Independent evolution of surfaces gets easier when the states are shared. Web, mobile, and an agent can all implement "invite a member" if the states are known. They cannot if each surface has a private idea of what "invited" means.
+
+## In an Agentic System
+
+Agents are now actors in the journey, not only authors of the code.
+
+A coding agent implementing a feature will follow the happy path in the ticket. Alternates, errors, and permissions are the parts it will improvise unless they are explicit. A journey artifact is a map: who acts, what happens, what fails, who is allowed, how the job ends.
+
+In-product agents need the same things a human path needs — entry, permission, failure, completion — plus a structured way to call the steps. If the human journey is incomplete, the agent journey will be a guess with tools attached.
+
+Delegation gets easier when the job is named. "Implement recovery for failed document upload" is a bounded task. "Make upload better" is an invitation to invent product behavior.
+
+Human approval belongs on permission changes and on new actors. Adding an agent that can change retrieval sources is a journey change, not a UI tweak.
+
+## What "First" Does Not Mean
+
+This is not wireframing. It is not a design system. It does not require BPMN, a service blueprint, or a state machine document for every feature.
+
+It does not replace Product First. You still need to know what and why before you map how someone finishes.
+
+It is not Design First. Describe what happens and why. How the interface expresses that — tokens, components, motion, copy — is a different decision. A complete flow can still look accidental. A beautiful screen can still trap someone in a state the flow never named.
+
+It is not Security First. Journeys place permission gates in the flow. Security owns the authorization policy behind them.
+
+It is not a GTM journey map. Acquisition sequencing belongs with Product.
+
+The smallest useful version is a short narrative for one critical job: actor, start, main path, two or three failures, who is allowed, what "done" means. Write more only where the product has already been burned by a missing state.
+
+## Spec
+
+Apply this: [principles/JOURNEYS.md](../principles/JOURNEYS.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Jeff Patton, *User Story Mapping*](https://jpattonassociates.com/story-mapping/) — the whole job as a narrative; walking skeleton before muscle. Method, not a requirement.
+- [Clayton Christensen et al., "Know Your Customers' 'Jobs to Be Done'"](https://hbr.org/2016/09/know-your-customers-jobs-to-be-done) — the job is the unit of analysis; screens are hired to finish it.
+- [Evolution of AI UX](https://gaboesquivel.com/blog/2026-01-evolution-ai-ux) — voice, chat, and admin as paths through one product, not as separate apps.

--- a/_first/articles/OPERATIONS.md
+++ b/_first/articles/OPERATIONS.md
@@ -1,0 +1,91 @@
+---
+title: Operations First
+status: draft
+description: Decide how you will see, support, and recover the running system before production becomes a black box — a green pipeline is not verified recovery.
+---
+
+# Operations First
+
+## Principle
+
+Decide how you will see, support, and recover the running system before production becomes a black box.
+
+## The Case
+
+Shipping is not the end of engineering work. It is when the system meets reality.
+
+I want to know what it is doing, what failed, for whom, and how to fix it — without archaeology. A product nobody can operate is a product that will fail quietly. Teams hesitate to ship systems they cannot see. Incidents stretch because nobody knows where to look. Agents cannot diagnose production issues from folklore.
+
+Amazon's line was you build it, you run it. The people who write the service own it in production. That was an organizational answer to a visibility problem: if someone else runs it, the people who can change it never feel the 3 a.m. The useful part for a small team is the same sentence without the org chart. If you shipped it, you should be able to see it, support it, and recover it.
+
+Charity Majors's observability argument is the other ancestor. Monitoring tells you about known-unknowns: the dashboards you thought to draw. Observability is how you ask new questions of a running system — the unknown-unknowns — without shipping a new dashboard first. Structured events, high cardinality, traces when a request crosses a boundary.
+
+You do not need Honeycomb-scale tooling on a brochure site. Importing that stack into a marketing page is how you confuse proportional with incomplete. You do need to not be blind. A 500 with no request id is the textbook blind spot: something failed, and you cannot find the request. The next question — which user, which tool, which deploy — is what observability is for. If you cannot ask it without shipping a new log line, you only had monitoring.
+
+The agentic delta is that production now has actors that are not humans clicking. An in-product agent needs identity, logs, retries, and a trace of what it did. A coding agent that "fixed" an incident has not finished until someone verified recovery in the running system. A green pipeline after a fix is necessary. It is not the same as the error rate coming back down.
+
+Product analytics are a different question. Events, funnels, and activation live with Product First. A 500 rate is whether the system is broken. A drop in completed sign-in is whether the product is working. Page on the first. Put the second on the validation board. Same warehouse is fine. Same dashboard pretending to be both is how you miss the outage and the drop-off.
+
+## Product Leverage
+
+A product that cannot be supported is a product that trains customers to leave.
+
+Runtime clarity is customer experience on the unhappy path. If a payment fails and nobody can find the request, the product did not merely have an engineering incident. It stranded a person mid-job. Journeys named the recovery. Operations is how you see whether recovery happened.
+
+It preserves the ability to change. Teams that cannot see production stop shipping. Fear is a product-strategy input: you will not experiment if every deploy is a coin flip in the dark.
+
+Time to market includes time to diagnose. A missing log field is a delay that shows up as "we are still looking." The smallest useful signal — one request id, one error code the support person can read — is a product investment.
+
+## Engineering Leverage
+
+Observability is a contract about what the running system will admit.
+
+Structured logs you can search. Metrics on the failure modes that matter. Traces when work crosses services. Alerts that fire on real problems. A runbook for the recovery you have already needed once. Those are how independent services stay operable: the next engineer, or the next agent, can ask what happened without guessing.
+
+Unix taste still applies: make systems easy to inspect. Fail noisily. Transparency is part of robustness. In production that means the failure is a record, not a screenshot in chat.
+
+Production agents need the same seriousness as a worker process. Identity so you know who acted. Logs so you know what they called. Retries with a budget so a loop cannot become a denial of service. If the agent is infrastructure, operate it like infrastructure. A prompt change that alters what the agent does in production is a deploy. Treat it like one: see it, support it, recover it.
+
+Verify recovery in the running system. Staging if that is what you have; production when the change is live. Pipelines got the change there. Operations confirms the plant actually improved.
+
+A runbook is not a wiki of wishes. It is the recovery you have already needed once, written so the next person — or the next agent — does not start from chat. If the failure has never happened, do not invent a novel. If it has, do not leave the steps in someone's head.
+
+## In an Agentic System
+
+Agents cannot debug a black box.
+
+Give them structured signals, not a story about "it felt slow last week." A coding agent diagnosing production should read logs, metrics, and runbooks, propose the smallest signal or fix, and wait for verification after deploy. If the only evidence is a green CI job, the agent will stop too early.
+
+If the logs are unstructured walls of text, the agent will guess the same way a tired human guesses. Readable failures are operations work, the same way they are pipeline work. The difference is when they fire: CI is the change. Production is the plant.
+
+In-product agents are production workload. If you cannot see which tool ran, with which inputs, for which user, you cannot support the feature and you cannot investigate abuse. That is operations, not a prompt tweak.
+
+The loop is the point: production signal → identify the issue → workflow routes work → implementation → pipeline deploys → operations verifies recovery. An agent can participate in that loop only if the signals exist and the verification step is named.
+
+"The tests passed" is a pipeline sentence. "The error rate came back down for the users who were failing" is an operations sentence. Do not let the first steal the second.
+
+## What "First" Does Not Mean
+
+Operations First is not a full SRE program for a side project. It is not fifty dashboards on day one.
+
+It is not Pipelines First. Pipelines deliver the change. Operations runs what was delivered. A green build is not verified recovery.
+
+It is not Security First. Security sets trust and permissions. Operations observes and recovers.
+
+It is not Product First. Product owns whether the bet is working: events, funnels, activation. Operations owns whether the system is healthy: logs, traces, error rates, alerts, recovery. A named activation metric with no event is unfinished product work, not an ops ticket.
+
+The smallest useful version: structured logs with a request id, one alert on the failure that would strand a user, a short note on how to recover. Add traces, SLOs, and on-call when the blast radius justifies them.
+
+You-build-it-you-run-it does not mean every engineer carries a pager on a brochure site. It means the people who can change the system can see it. If that is one person and a log search, say so. If it is a rotating on-call, write the runbook. The principle is visibility and recovery, not a staffing model.
+
+Do not page on a funnel. Do not treat a 500 as a growth experiment. When a drop-off and an error rate move together, look at both files: Product for the bet, Operations for the plant. The warehouse can be shared. The question cannot.
+
+## Spec
+
+Apply this: [principles/OPERATIONS.md](../principles/OPERATIONS.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Charity Majors, "Observability: A Manifesto"](https://www.honeycomb.io/blog/observability-a-manifesto) — unknown-unknowns; monitoring is not the whole job.
+- [Werner Vogels, ACM Queue interview (2006)](https://www.allthingsdistributed.com/2006/05/the_amazon_technology_platform.html) — you build it, you run it.
+- [AI Agents are Infrastructure](https://gaboesquivel.com/blog/2026-05-ai-agents) — production agents need identity, logs, retries, and a way to see what they did.

--- a/_first/articles/PIPELINES.md
+++ b/_first/articles/PIPELINES.md
@@ -1,0 +1,92 @@
+---
+title: Pipelines First
+status: draft
+description: Treat automated validation and delivery as part of the development feedback loop — including the agent loop — not as a ritual after the real work.
+---
+
+# Pipelines First
+
+## Principle
+
+Treat automated validation and delivery as part of the development feedback loop — including the agent feedback loop — not as a ritual after the real work.
+
+## The Case
+
+A change is not done when it compiles on my machine. It is done when it passes the same checks everyone else relies on, and when it can reach the environment it needs to reach.
+
+Pipelines are how a team scales trust. For agents, CI is the ground truth: implement, run checks, read failures, fix or escalate, run again. I do not recommend heavy infrastructure for a small project. I do recommend that the path from source to deployable is explicit and automated at the level the project actually needs.
+
+Manual release steps get skipped. Agents merge changes that break CI because nobody wired the failure back into the loop. "Works locally" becomes a recurring incident. The agentic version is worse: the agent sandbox is green. That is not the project's pipeline.
+
+Martin Fowler's continuous integration is the first ancestor: integrate often, on a shared mainline, with an automated build. Humble and Farley's deployment pipeline is the rest of the path. The commit stage is BUILD: compile, unit test, and produce the artifact once. Later stages promote that same artifact. They do not rebuild a different binary per environment. Twelve-factor says the same split as build / release / run. The factory promotes an artifact. It does not invent a new one at the door of staging.
+
+Jez Humble's product sentence is still the right one: work so that the software is always in a releasable state. Small batches make it economic to get feedback from working software. I wrote about this years ago as keeping a codebase always deployable and tested. That still holds. What changed is who consumes the log.
+
+The same staged-gate pattern shows up in marketing automation and RevOps: a lead is promoted through stages, with gates, with feedback when something stalls. The isomorphism is real. The artifact is not. A lead is not a binary. This station is software delivery. GTM fields stay in Product.
+
+The path I want is boring on purpose:
+
+change → format → lint → typecheck → test → build → preview → deploy → verify
+
+Not every project needs every step on day one. A static site and a payments API do not get the same graph. Missing a typecheck on a TypeScript monorepo is not proportional. Adding canary orchestration to a weekend prototype is not proportional either.
+
+## Product Leverage
+
+Pipelines are usually sold as engineering hygiene. The product consequence is the ability to learn.
+
+Small batches make experiments cheap. A/B tests only exist as a product practice if shipping is cheap enough to do on purpose. If a release is a ceremony, you will not experiment. You will batch guesses.
+
+Time to market is waiting on a path that is not automated. Integration phases, hardening weeks, and "the person who knows how to deploy" are product delays wearing ops clothing.
+
+Preview environments, when the product actually needs them, are how you review the product, not only the diff.
+
+Always-releasable software also preserves optionality. You can change direction at the next commit instead of at the next release train.
+
+## Engineering Leverage
+
+A pipeline is a contract about what "integrated" means.
+
+The same gates for every meaningful change. Local commands that match CI, so humans and agents are not debugging two realities. Failures that are readable, so the next action is obvious.
+
+That is independent evolution of services and apps: you can change one thing if the pipeline tells you what broke.
+
+Flaky or skipped jobs destroy the loop. Noise trains people and agents to ignore the gate. A slow pipeline that nobody waits for is a manual process with YAML.
+
+Pipelines First does not define what good means. That is Quality First. Quality names the bar. Pipelines run it. A green build that never ran the checks you care about is automation of the wrong thing.
+
+Build once, deploy many. If staging and production compile different trees, you are not promoting an artifact. You are hoping two builds coincide.
+
+## In an Agentic System
+
+Agents generate code faster than humans can babysit it. The pipeline is how you refuse to take their word for it.
+
+They implement, CI runs, they read the log, they fix or they escalate. That only works if CI is actually wired, actually run, and actually trusted. Give an agent a repo without CI and it will optimize for "looks done." Give it a sandbox that is not the pipeline and it will optimize for the sandbox.
+
+Readable failure output is agent context. A 4,000-line log with no failed test name is not. Unreadable logs break the loop.
+
+Do not add pipeline complexity an agent cannot operate. The loop has to be closable.
+
+## What "First" Does Not Mean
+
+Pipelines First is not Kubernetes for a brochure site. It is not five workflow files because other repos have five.
+
+It is not Workflow First. Pipelines produce signals. Workflow is how humans and agents respond and proceed.
+
+It is not Quality First. Quality names the bar. Pipelines execute the checks.
+
+It is not Operations First. Pipelines get a change into production. Operations is what you do after it is there. A green pipeline is not verified recovery.
+
+It is not a marketing pipeline. Stages and gates are a shared shape. The artifact here is software.
+
+The smallest useful version: the project's real lint, type, test, and build commands run on every meaningful change, locally and in CI. The commit stage produces the artifact that later stages deploy. Deploy is documented and repeatable.
+
+## Spec
+
+Apply this: [principles/PIPELINES.md](../principles/PIPELINES.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Jez Humble and Dave Farley, *Continuous Delivery*](https://continuousdelivery.com/) — always releasable; the deployment pipeline; commit-stage build once, deploy many.
+- [Martin Fowler, "Continuous Integration"](https://martinfowler.com/articles/continuousIntegration.html) — integrate often; automated build as the first gate.
+- [The Twelve-Factor App, Build, release, run](https://12factor.net/build-release-run) — strict separation; the artifact is promoted, not rebuilt.
+- [On Continuous Delivery](https://gaboesquivel.com/blog/2015-07-continuous-delivery) — the same loop before agents were the ones reading the log.

--- a/_first/articles/PRODUCT.md
+++ b/_first/articles/PRODUCT.md
@@ -1,0 +1,103 @@
+---
+title: Product First
+status: draft
+description: Define what you are building, for whom, why it is worth building, and how you will know — before the last merge becomes the specification.
+---
+
+# Product First
+
+## Principle
+
+Define what you are building, for whom, why it is worth building, and how you will know — before implementation becomes the specification.
+
+## The Case
+
+Software projects fail in a quiet way: they keep moving. Features ship. Architecture hardens. Nobody can point to a file that says what the product is for, who it is for, what would count as working, and what is out of scope.
+
+Then the codebase becomes the brief. The last merge is the spec. Two surfaces contradict each other because they were built from different unspoken products. You spend a week arguing about a screen when the real question was whether the capability belonged at all.
+
+Implementation is good at revealing better options. It is a poor author of goals. Once a stack, a data model, and a set of screens exist, reversing the goal is a rewrite wearing a feature's clothes.
+
+Lee Robinson describes product engineers as people who work backwards from the desired experience to the technologies that enable it. Frontend versus backend is not the interesting split. The interesting split is whether you are building toward a product outcome or toward a layer of the stack. Technology choices are means. If nobody uses the product, the library you picked did not matter.
+
+Amazon's Working Backwards habit is the same idea at a heavier weight: start from the customer and the press-release version of the product, then let that force the work. You do not need to import the PR/FAQ ceremony. You do need the habit. Write the bet before the stack hardens.
+
+Marty Cagan's distinction between discovery and delivery is useful as contrast, not as a methodology to import. Discovery is how you find out whether an idea is worth building. Delivery is how you build it well. Most teams over-invest in delivery. Product First is the engineering version of that warning: do not let delivery invent the goal.
+
+AI makes the gap more expensive, not smaller. Robinson's later point is that generation is most useful from zero to something, and that the last stretch requires an opinion about what you are actually trying to build. Agents that can ship a feature in an afternoon can also ship the wrong feature with confidence. If product intent lives only in chat, the next session reconstructs it from whatever the UI happens to do. If you do not name non-goals, they invent scope. If you do not name success, they treat "it compiles" as done.
+
+At Wink I was Lead Engineer for Costa Rica's first neobank. Choosing the AWS and React Native stack and recruiting the team were the same decision: what we were building determined who we needed and what the system had to survive. The product constraint came first. The implementation followed. The business goal — regulated access to accounts on a phone — was not something you could discover from a component library.
+
+The current job on LegalAgent is narrower and just as load-bearing: a lawyer retrieves case context in the assistant without leaving the conversation. That sentence is intent. It is not a conversion rate. If we do not write it down, the next session will finish a different product.
+
+## Product Leverage
+
+You get alignment between intent and implementation. A change can be judged against a goal instead of against taste. Scope stops expanding by default because something was ruled out on purpose.
+
+You get a way to change direction without pretending nothing was decided. When the product changes, you update the file. The alternative is a silent pivot encoded in a pull request that nobody will find six months later.
+
+You avoid premature product decisions of the wrong kind. Writing the goal down is not freezing the solution. It is separating the job from the current approach. If the job is named, the implementation can change. If only the implementation exists, the job is whatever shipped.
+
+You get experiments that can actually fail. "Make it better" is not a product outcome. A named metric with a window is a bet you can keep, iterate, or kill. Analytics is how that definition becomes visible. Naming activation without shipping the event is the same accident as naming a capability without a boundary: the next session will guess. The tracking plan ships with the feature.
+
+Go-to-market belongs in the same artifact. Shipping is not distribution. A capability that only the people who built it can find is not a product outcome. For an internal tool that still means who gets access, how they hear about it, and what the first successful use looks like.
+
+Time to market improves when you stop building adjacent ideas that were easy to code. Non-goals protect the calendar.
+
+If the product is a business, market size and unit economics belong in the brief as constraints, not as a pitch-deck appendix. The field list lives in the spec. Do not invent TAM or LTV to make the file look finished.
+
+## Engineering Leverage
+
+Engineers cannot design a system against an implied product. They guess, then they encode the guess.
+
+A written goal, a written non-goal, and a written metric change the architecture conversation. You stop arguing about frameworks and start arguing about constraints: regulated money movement, retrieval quality, a latency number that is part of the product. Those constraints decide the stack more honestly than a trend.
+
+They also decide what not to abstract. If the product is one actor and one job, you do not need a platform. Product First is how that distinction stays visible.
+
+Product-engineering metrics are not engineering-productivity metrics. Cycle time and CI greenness tell you whether the team can change the product. They do not tell you whether the product worked.
+
+Testability has nothing to attach to without success criteria. Quality First names the bar that gates a release. Product First names the outcome you will observe after people actually use it, and ships the analytics that make that observation possible. Mixing those two produces a launch blocked on thirty-day retention, or a launch that treated passing tests as market validation.
+
+The event taxonomy is a product contract. A 500 rate is whether the system is broken. A drop in completed sign-in is whether the product is working. Page on the first. Put the second on the validation board.
+
+## In an Agentic System
+
+Coding agents fill gaps. That is their strength and the failure mode.
+
+If the gap is "what is this product," the agent will answer from the file tree, the README, and the running UI. Those are facts about what exists. They are not always facts about what should exist. Without a product artifact, the agent treats shipped behavior as intent. That is how a merge becomes the specification.
+
+A short brief gives agents context they should not infer: users, business goals, non-goals, GTM, success metrics, the tracking plan, and which hypotheses are still unproven. You can say "implement this change" without also saying "decide whether we are a marketplace now."
+
+Generation gets you a prototype. Finishing requires an opinion. The opinion has to live in a file, or every session will finish a different product.
+
+An agent can notice that the UI, the brief, and the numbers disagree. A human still decides which one is wrong. Scope, priority, success metrics, event names, GTM, and pricing are consequential. Agents should propose updates to the artifact, not silently decide them.
+
+## What "First" Does Not Mean
+
+Product First is not a product-management methodology. It does not require a 40-page PRD, a pirate-metrics dashboard, or a weekly validation board meeting.
+
+It does not mean writing a novel before you are allowed to learn. The smallest useful version is a page: problem, users, business goal, non-goals, how it reaches people, one to three metrics with a window, the events that will show them, open questions. If money is the point, add the model you currently believe, marked measured or unproven.
+
+It does not mean Mixpanel on day one. The smallest useful analytics is the few events that would change what you build next.
+
+It does not mean gating a ship on post-launch metrics you cannot observe yet. Acceptance criteria belong with Quality. Success metrics are observations after use.
+
+It does not mean the spec never changes. It means when the spec changes, you update the file.
+
+It is not Journeys First. Product says what, why, and how we will know. How someone finishes the job is a different document.
+
+It is not API First. Desired capabilities are product. How systems communicate at a boundary is a contract.
+
+It is not Operations First. Product owns whether the bet is working. Operations owns whether the system is healthy. A named metric with no event is unfinished product work, not an ops ticket.
+
+## Spec
+
+Apply this: [principles/PRODUCT.md](../principles/PRODUCT.md). The optional finance and tracking fields live there. Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Lee Robinson, "Product Engineers"](https://leerob.com/product-engineers) — work backwards from the desired experience; visually complete is not done.
+- [Andrew Zigler, "The Rise of Product Engineers in the AI-Driven Era"](https://linearb.io/blog/the-rise-of-product-engineers-in-the-ai-driven-era) — Robinson on code last, and why generation still needs an opinion.
+- [The Skillset of a Product Engineer](https://gaboesquivel.com/blog/2025-03-the-product-engineer) — outcomes over implementation; analytics as part of the job.
+- [Marty Cagan, "Discovery vs. Delivery"](https://www.svpg.com/discovery-vs-delivery/) — do not let production-quality delivery substitute for knowing what is worth building.
+- [Working Backwards, PR/FAQ](https://workingbackwards.com/concepts/working-backwards-pr-faq-process/) — a heavier form of the same habit for major bets. Optional. Not the default artifact.

--- a/_first/articles/QUALITY.md
+++ b/_first/articles/QUALITY.md
@@ -1,0 +1,87 @@
+---
+title: Quality First
+status: draft
+description: Name what good means — acceptance, tests, evals, performance — before anyone optimizes toward an undefined target.
+---
+
+# Quality First
+
+## Principle
+
+Name what good means — acceptance, tests, evals, performance — before anyone optimizes toward an undefined target.
+
+## The Case
+
+I do not ask anyone to "make it better" without saying what better means.
+
+Quality is broader than tests. Tests are one way to prove behavior. For interfaces, visual and interaction validation matter. For probabilistic AI features, evals may be the right tool. For performance, budgets beat vibes. Name the bar before you optimize. Otherwise you ship something that passes review and still fails users.
+
+Without quality definitions, teams debate taste as if it were fact. Agents iterate until something looks done. Regressions slip through because nothing asserted the old behavior. AI features ship without evals and degrade without a failing check.
+
+Test First and TDD are the ancestors for deterministic code: write the assertion, then the behavior. Mike Cohn's test pyramid, which Martin Fowler later popularized, is a portfolio argument: many fast, narrow checks, fewer expensive broad ones. Shift-left is the same instinct — catch the failure while it is still a diff. It is not a religion, and it assumed you could assert equality.
+
+The useful distinction now is between a test and an eval. A test asserts a property that must always hold and fails the build when it does not. An eval scores quality across a dataset and reports a distribution, gated on a threshold. Schema, auth, and tool calls are still tests. Generated language is an eval. Mixing those two is how you get either a flaky CI or a product with no protection. Hamel Husain's argument is the practical one: unsuccessful LLM products usually failed to build an evaluation system, not a prompt.
+
+The agentic delta is that agents optimize whatever you measure, including "looks done." Write the criteria, then loop until they hold. If the plan is wrong, perfect execution only gets you to the wrong place faster.
+
+I have used a simple bias for a long time: unit tests are useful; functional tests are how you know the system behaves. That still holds for deterministic code. For retrieval, generated language, and tool-using agents, the functional question is an eval: does the output still do the job across cases you care about? One sentence of intent is not that dataset.
+
+## Product Leverage
+
+Quality is how the product stays itself while it changes.
+
+A named bar is how you keep customer experience from drifting. The happy path that worked last month should still work. Retrieval that lawyers depend on should not silently get worse after a prompt edit. That is product integrity, not coverage percentage.
+
+It makes experiments honest at the behavior layer. Journeys become acceptance tests. Product First's post-launch metrics are a different question — they need events in the product. Without that split, "done" is either a feeling or a dashboard you waited on before shipping.
+
+Time to market improves when regressions are cheap to catch. The alternative is a freeze, a hero QA pass, or a production surprise.
+
+A named bar also makes the bet honest at release. Product still owns what happens after people use it. Quality owns whether this change is allowed to reach them. Mixing those two is how you freeze a good fix behind a dashboard that is still empty, or ship because CI was green.
+
+Performance budgets are product decisions. Latency is part of checkout, voice, and search. If the budget is unstated, engineering will spend it.
+
+## Engineering Leverage
+
+Explicit criteria make automation possible. Pipelines can run a bar. They cannot invent one.
+
+Behavior-focused tests protect contracts and critical paths without coupling to implementation trivia. That is independent evolution: you can change internals if the assertions still hold.
+
+Failures should be actionable. Noise trains people and agents to ignore the gate. A deleted assertion without a written rationale is a decision made by a diff.
+
+For AI features, keep deterministic checks at the base: schemas, tool permissions, retrieval tenancy, fallbacks. Put scored evals where the output is probabilistic. Do not put an expensive judge on every commit if that prices the gate out of existence.
+
+The pyramid still helps you place the cheap checks. Unit and contract tests belong near the commit. Broad browser checks and evals are fewer, slower, and should assert the job, not the implementation trivia. Quality names that mix. Pipelines is what actually runs it.
+
+## In an Agentic System
+
+Agents optimize toward whatever you measure, and toward "looks done" if you measure nothing.
+
+A named bar is how you delegate implementation without delegating the definition of good. The agent can loop on tests, browser checks, and evals. It cannot honestly loop on "make it better."
+
+Validation is the point of contact. Existing project commands, not a parallel suite the agent invented. If criteria cannot be met without a product decision, that is an escalation, not a silent weakening of the test.
+
+For in-product agents, evals are how the product knows the agent still does the job. That is Quality First applied to a probabilistic actor, not a new principle.
+
+## What "First" Does Not Mean
+
+Quality First is not Test First alone, and it is not 100% coverage on everything. A prototype does not need a cathedral of tests.
+
+It does not replace Pipelines First. Quality defines what to validate. Pipelines run the validation. Mixing those two is how you get a green build that never checked the thing users will feel.
+
+It does not replace Product First. Product names the outcome you will observe after people use the thing, and ships the events that make that observation possible. Quality names the bar that gates a release. Do not block a ship on thirty-day retention. Do not treat a green pipeline as market validation.
+
+The smallest useful version: acceptance criteria for this change, plus the smallest mechanism that actually protects the claim. One test on a critical path beats a suite of assertions nobody trusts.
+
+"Looks done" is not a bar. A screenshot of the happy path is not a bar. A green pipeline that never ran the eval is not a bar. Name the claim. Pick the instrument. Loop until it holds, or escalate that the claim was wrong.
+
+For retrieval, that instrument is usually an eval over cases you care about, not a unit test of the wrapper. One sentence of product intent is the job. The eval is how you know the job still holds after a prompt edit.
+
+## Spec
+
+Apply this: [principles/QUALITY.md](../principles/QUALITY.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Martin Fowler, "Test Pyramid"](https://martinfowler.com/bliki/TestPyramid.html) — a portfolio of checks, not a coverage cult.
+- [Hamel Husain, "Your AI Product Needs Evals"](https://hamel.dev/blog/posts/evals/) — unsuccessful LLM products usually lack an evaluation system, not a prompt.
+- [Engineering in the AI Era](https://gaboesquivel.com/blog/2026-02-engineering-ai-era) — declarative criteria and loops when generation is cheap.

--- a/_first/articles/SECURITY.md
+++ b/_first/articles/SECURITY.md
@@ -1,0 +1,95 @@
+---
+title: Security First
+status: draft
+description: Identify what you are trusting, protecting, exposing, and allowing — including the agent as a principal — before architecture buries those decisions.
+---
+
+# Security First
+
+## Principle
+
+Identify what you are trusting, protecting, exposing, and allowing — proportionally to actual risk — before architecture makes security assumptions expensive to change.
+
+## The Case
+
+Security debt compounds quietly. Auth rules drift between handlers. Secrets land in logs. External input is trusted too early. Agents get broad tool access by default because it is convenient. A breach or a leaked key costs more than the hour it would have taken to name the trust boundary while it was still movable.
+
+That is not a new observation. Microsoft's Security Development Lifecycle put threat modeling and security requirements in the development process instead of at the end. DevSecOps later named the same move for continuous delivery: if you only scan after the release train has left, you are auditing an accident. Shift-left security is the slogan. The useful part is earlier: identify what you are trusting, protecting, exposing, and allowing while those decisions can still change the architecture.
+
+The agentic delta is a new principal, not a new slogan. A coding agent with file access, network, and deploy credentials is a service account that talks. An in-product agent with tools is a caller on your API. Treat either one like a trusted colleague and you have granted standing that no human reviewer would give a contractor on day one.
+
+Least privilege still applies: the smallest access that can do the job. Least agency is the extra constraint agents need. Access is what you can reach. Agency is what you are allowed to do without asking. An agent that can read the production database is already a risk. An agent that can drop it because the prompt said "clean up" is a different class of risk. High-impact actions wait for a human. That is not ceremony. That is the only recovery story that still works when the actor is fast and confident.
+
+At Wink I was Lead Engineer for Costa Rica's first neobank. The product sat on partner-bank APIs and biometrics. The interesting decisions were not "add auth later." They were who is allowed to move money-shaped state, and what the mobile app was allowed to see. That class of constraint does not get cheaper after the architecture is set. A payments product and a marketing site do not share a bar. Pretending they do either slows the site down or under-protects the money.
+
+Prompt injection is a real surface on LLM products — untrusted text steering tools. I have written about it as a concrete attack, not as a vibe. It is one surface, not the whole principle. Most of the work is still ordinary: authentication, authorization, secret handling, input validation, dependency hygiene, least privilege. Agents add a new actor with tools. Narrow the tools. Validate the inputs. Log the actions. Gate anything destructive. Do not put secrets in the prompt or the transcript.
+
+Do not reprint a generic top-ten list and call it the trust model. The project's actual exposure is the input: public internet, partner APIs, money-shaped state, documents a model can retrieve, credentials in the environment. Name those. The rest of the catalog is reference, not the decision.
+
+## Product Leverage
+
+Trust is a product feature. People use a product that holds money, documents, or identity because they believe the wrong person cannot act.
+
+Naming who may do what is how you keep that belief true across surfaces. If the web app checks a role and the API does not, the product rule is the weaker of the two. Customers do not experience "the UI was careful." They experience the transfer that went through.
+
+Proportional rigor is also a product decision. An internal admin used by three operators does not need the same control set as regulated account opening. Over-securing a brochure site delays a launch that had almost no blast radius. Under-securing a money path is how you ship a product you cannot stand behind.
+
+Optionality follows the same split API First uses for capabilities. A capability with a trust boundary can be exposed to a partner, a mobile client, or an agent without cloning ad-hoc checks. A capability whose permission lives in one handler cannot.
+
+Time to market improves when you stop discovering auth in production. You still ship a thin path. You ship it with a named gate, not with a comment that says TODO.
+
+An in-product agent that can retrieve documents is a reader with a new interface. The permission is still "who may see this case." Do not invent a second authorization story because the caller is a model.
+
+## Engineering Leverage
+
+Security assumptions that live only in code are architecture you cannot review.
+
+Auth at the boundary, not scattered per handler, is the same move as a consistent error model: one place to change the rule, one place to test it. Secrets in the environment, not in the repo and not in logs, are how you keep credentials from becoming folklore in a transcript. Input validation on the edge is cheaper than sanitizing after a tool has already run.
+
+An agent permission list is an interface. Name the tools, the files, the networks, and the destructive commands. If the list is "whatever the session inherited," you do not have a permission model. You have a default.
+
+Independent evolution of services only works if the trust model is shared. Two services that disagree about who may read a customer record will disagree in production.
+
+Scanning is a signal, not a substitute for the decision. A dependency audit that nobody reads is the security version of a pipeline nobody trusts. The scan belongs in the project's existing checks. The decision belongs in a file: what is sensitive, who may touch it, what waits for a human. If those three are only in a scanner dashboard, the next session will not see them.
+
+## In an Agentic System
+
+The agent is a principal.
+
+A coding agent can read secrets from env files, commit them, log them, or paste them into chat. It can run a destructive command because the prompt said "clean up." It can widen a permission because the feature was easier that way. None of that requires malice. It requires a missing rule.
+
+Give the agent a role: prefer read-only inspection, no unnecessary secrets, human approval for trust-boundary edits and destructive operations. That is least agency. The agent can propose a permission change. It should not merge one.
+
+That role has to be in the project's instructions, not only in this essay. If the session inherits admin credentials because that was convenient for local development, the written rule lost. Treat the agent like a service account you would actually issue: named, narrow, logged, revocable.
+
+In-product agents are the same pattern with a product surface. A tool is an API call with a name. If the model can be steered by untrusted content into calling that tool, you have an injection surface on top of an authorization surface. Fix both. Do not treat the injection writeup as the whole security program.
+
+Stop for a human when the change is a trust-boundary edit, a secret, or a destructive operation. Propose the rule. Do not merge it. That is the same gate Workflow names. This station is why the gate exists.
+
+## What "First" Does Not Mean
+
+Security First is not AI security theater. It is not threat-modeling every button. A low-risk prototype does not need a full threat model to ship.
+
+It does not mean blocking a launch on perfect security. It means the controls match the blast radius, and the gaps are named.
+
+It does not replace Operations First. Security defines trust and protection. Operations is how you see and recover at runtime. You need both. They are not the same file.
+
+It does not replace API First. The contract is the shape of the call. Who may invoke it, and what they may see, is a trust decision.
+
+It does not replace Workflow First. Human gates for secrets and destructive work live on the conveyor. This station names what those gates are protecting.
+
+The smallest useful version: name what is public, what is authenticated, what is admin, what is secret, and what an agent may not do. Write that down. Enforce it at the boundary. Scale the rest to the actual risk.
+
+A prototype on a private URL is not "no security." It is a smaller bar: secrets still stay out of git, the agent still does not get production credentials, and destructive commands still wait. The bar grows with exposure. It does not start at zero.
+
+Do not confuse secrecy with authorization. Hiding a route is not a permission model. A client that is "internal" still calls an API. The agent that can see the handler still needs a rule. Write who may invoke, not only who may know the URL.
+
+## Spec
+
+Apply this: [principles/SECURITY.md](../principles/SECURITY.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Microsoft, Security Development Lifecycle](https://www.microsoft.com/en-us/securityengineering/sdl) — security requirements and threat modeling inside the development process, not after.
+- [OWASP, DevSecOps Guideline](https://owasp.org/www-project-devsecops-guideline/) — shift-left as continuous security in the delivery loop.
+- [Prompt Injection](https://gaboesquivel.com/blog/2025-06-prompt-injection) — untrusted text steering tools. One surface. Not the whole principle.

--- a/_first/articles/WORKFLOW.md
+++ b/_first/articles/WORKFLOW.md
@@ -1,0 +1,90 @@
+---
+title: Workflow First
+status: draft
+description: Make the path from intent to validated change explicit enough that humans, agents, and automation can cooperate without reconstructing it every time.
+---
+
+# Workflow First
+
+## Principle
+
+Make the path from intent to validated change explicit enough that humans, agents, and automation can cooperate without reconstructing the process every time.
+
+## The Case
+
+I care less about which methodology name is on the wall and more about whether work can move from idea to a shipped, validated change without starting from zero.
+
+Who decides what? Where does state live? When does a human approve? When does an agent hand off to CI, or CI back to an agent? Communication is not meetings. It is the transfer of useful context between actors. Durable when it affects future work. Ephemeral when it is coordination. If the workflow is only in people's heads, agents cannot help and humans cannot scale.
+
+Implicit workflows do not survive contact with more than one person, or with an agent. Prior context lived in chat, so the next session repeats the analysis. Reviews happen without the plan. CI fails and nobody owns the next action. Production feedback never lands in an issue.
+
+Kanban and Scrum can be tools inside a workflow. They are not the workflow. Ryan Singer's Shape Up is a useful contrast: work is shaped before it is bet on, and betting is a real decision, not a backlog that pretends everything is equally intended. The transferable idea is not six-week cycles. It is that unshaped work should not enter the building phase just because someone started typing.
+
+The work loop lives here, and only here:
+
+idea → plan → implement → review → pipeline signals → approval → release → learning
+
+What matters is that each step has an actor, an input, an output, and a place for state. A consequential architectural choice goes in an ADR or a project doc — Documentation keeps it. Automated validation is a CI result — Pipelines produce it. Work state lives in an issue, a task, or a pull request. Temporary coordination stays in a comment or chat.
+
+The agentic delta is a delegation protocol. Generation is cheap only if the path is explicit. Give success criteria and a loop. Human approval is a boundary, not a vibe: product scope, security-sensitive changes, destructive operations wait. Everything else can move if the files are in order.
+
+Those gates are factory control. The other stations point at them. They do not reprint them. If the path is "the agent just does it," you do not have a workflow. You have a hope that the next session will be careful.
+
+## Product Leverage
+
+A product that cannot change on purpose is a product stuck in its last heroic effort.
+
+Workflow First is how you keep the ability to change direction. Small, reviewable changes with a visible state beat a month of private work that lands as a surprise. Learning from production only happens if the signal can become work, and work can become a release.
+
+Time to market is mostly waiting: waiting for context, waiting for review, waiting for someone who "knows how we do this." An explicit path removes that wait without adding status theater.
+
+A plan in a file is cheaper than a recap in chat. A PR that points at the issue is cheaper than a branch with no owner. Those are product-speed moves wearing process clothes.
+
+It also reduces product coupling to particular people. If only one person knows how a release happens, the product's roadmap is that person's calendar. Issues, PRs, and plans are how the product continues when that person is not in the room — including when the next actor is an agent.
+
+A support ticket that never becomes an issue, a production error that never becomes a fix, an agent that implements without a plan: those are product failures with process costumes.
+
+The work loop is the conveyor. Stations dump work onto it. Pipelines are the automated stretch. Documentation is what remains after a handoff. If you keep a third loop in your head, you will reconstruct the process every time — which is the failure this station exists to prevent.
+
+## Engineering Leverage
+
+Explicit handoffs are an interface between actors, the same way an API is an interface between systems.
+
+Inputs and outputs at each step make parallel work possible. Review has a plan to read. CI has a branch to check. The next agent has files instead of a recap.
+
+State in issues and PRs is observable. Chat is not. That is testability for the process itself: you can see what is in flight, what is blocked, and what is waiting on a human.
+
+Approval boundaries are clearer failure modes. A destructive change that requires a human is a named gate, not a hope that someone was watching.
+
+This is not more tools. It is fewer implicit ones. One place for work state. One path for validation. One rule for what gets written down.
+
+## In an Agentic System
+
+Agents cannot follow a process that lives in one person's head.
+
+They need to know where work state lives, what "done" means, when to stop and ask, and where to put findings that will matter later. Inspect, propose, implement in reviewable chunks, validate through existing CI, escalate consequential decisions.
+
+Human gates are factory control: product scope, security, destructive ops. Without that, an agent either asks about everything or about nothing.
+
+It also routes system signals back into work. CI failure → fix or escalate. Production signal → issue → change → pipeline → verify. An agent can participate in that loop only if the loop exists.
+
+Agent-to-agent handoff is the same rule as human-to-human: enough context in durable form that the next actor does not need the transcript.
+
+## What "First" Does Not Mean
+
+Workflow First is not more meetings or status theater. It is not a required issue tracker or a required PR template.
+
+It is not Pipelines First. Pipelines produce signals. Workflow is how humans and agents respond and proceed.
+
+It is not Documentation First. Workflow decides when context is created and handed off. Documentation keeps it. Chat is not the system of record — that sentence is owned there.
+
+The smallest useful version: work state in an issue or PR, a short plan for non-trivial work, CI as the validation step, a named human gate for destructive or product-consequential changes. You do not need Shape Up, Scrum, or a workflow engine.
+
+## Spec
+
+Apply this: [principles/WORKFLOW.md](../principles/WORKFLOW.md). Return to the [factory map](../ABOUT.md).
+
+## Further Reading
+
+- [Ryan Singer, *Shape Up*](https://basecamp.com/shapeup/) — shaping before building; betting as a real decision. Use as contrast, not as a required method.
+- [Engineering in the AI Era](https://gaboesquivel.com/blog/2026-02-engineering-ai-era) — constraints and review while generation gets cheaper; the loop has to be explicit.

--- a/_first/basilic/API.md
+++ b/_first/basilic/API.md
@@ -1,0 +1,86 @@
+# API First
+
+## Principle
+
+Define the capability and its boundary before consumers couple to an accidental implementation.
+
+## Statement
+
+I treat the capability and its boundary as a design decision, not an implementation leftover. Before a second consumer depends on a shape, I want to know what goes in, what comes out, what fails, which Security-owned authorization requirement applies, and how denial appears. That contract might be HTTP, a typed module, an event, a CLI, or an agent tool. The format matters less than making the boundary explicit on purpose.
+
+## Outcome
+
+Meaningful boundaries have explicit inputs, outputs, errors, and references to applicable authorization requirements. Implementations enforce those requirements and conform, or the contract is updated deliberately. Agent tools have the same explicitness as HTTP routes. A second consumer can be written without reading the handler.
+
+## Artifacts
+
+- **Fact:** Contract source: TypeBox on Fastify routes in `apps/api/src/routes/` ([api.mdx](../../apps/docu/content/docs/architecture/api.mdx), [ADR 009](../../apps/docu/content/docs/adrs/009-api-architecture.mdx))
+- **Fact:** Generated spec: [`../../apps/api/openapi/openapi.json`](../../apps/api/openapi/openapi.json) — do not edit by hand
+- **Fact:** Generated client: `packages/core` via `pnpm generate`. Handwritten hooks: `packages/react`
+- **Fact:** Tags: `auth`, `account`, `ai`, `health`. Catalog: `/reference` and `/reference/openapi.json`
+- **Fact:** Consumers: `apps/web` (`@repo/core` + `@repo/react`); `packages/cli` (API key Bearer); other languages via OpenAPI. `apps/mobile` is not a consumer yet. `apps/docu` has no API.
+- **Fact:** Errors: catalog `{ code, message }` via `sendCatalogError` in `apps/api/src/lib/catalogs/mapper.ts`. Sentry gets the real error (`@repo/error`). Never leak stacks.
+- **Fact:** `createClient` modes: no-auth, JWT (`getAuthToken` / refresh), apiKey (`bask_…`)
+- **Fact:** Drift check: `pnpm generate && git diff --exit-code -- apps/api/openapi/openapi.json packages/core/src/gen` (also `api-e2e.yml`)
+- **Fact:** Generation how-to: [openapi-generation.mdx](../../apps/docu/content/docs/development/openapi-generation.mdx)
+- **Drift:** Architecture index “API as source of truth” vs routes/TypeBox generate OpenAPI. Follow TypeBox. ADR 009 already says Fastify routes are the source.
+- **Unresolved:** public versioning/idempotency policy beyond regenerate-on-change; MCP server as a shipped app; GraphQL secondary interface (ADR 009 optional)
+
+Who may call is Security. This station owns how credentials and denial appear on the contract.
+
+## Minimum Useful Artifact
+
+- capability: one Fastify route file + TypeBox schema
+- inputs, outputs, stable identifiers in TypeBox (then generated OpenAPI)
+- errors: catalog code; denial 401/403 as shipped
+- authorization reference: public, JWT session, or API key — policy in SECURITY.md
+- versioning: do not hand-edit OpenAPI; breaking change is a TypeBox change plus generate
+- contract check: generate + `git diff --exit-code`
+
+## Recipe
+
+1. Inspect `apps/api/src/routes/`, TypeBox, OpenAPI, `@repo/core`, `@repo/react`, CLI, error catalog, tests.
+2. Understand capabilities and consumers (web, CLI, not mobile).
+3. Identify undocumented boundaries, spec/implementation drift, inconsistent errors.
+4. Propose the smallest useful contract change. Keep intentional existing decisions.
+5. Make inputs, outputs, errors, and denial explicit in TypeBox. Point at Security for who may invoke.
+6. Implement against the contract. Do not let the handler invent a parallel shape. Do not edit `openapi.json`.
+7. Validate with generate + drift check and API Vitest (`fastify.inject()`).
+8. Update generated OpenAPI and `@repo/core` in the same work; handwritten `@repo/react` hooks when the UI needs them.
+
+## Validation
+
+- A second consumer can be written against OpenAPI / `@repo/core` without reading the handler.
+- Request and response shapes match TypeBox → OpenAPI, or the discrepancy is named.
+- Errors follow the catalog, not a dialect per endpoint.
+- Authorization is referenced and enforced at Fastify, not redefined as comments. Policy lives in Security.
+- CLI has name, inputs, outputs, and failure behavior (`packages/cli`).
+- Breaking changes are visible before merge (drift job).
+
+## Definition of Done
+
+Contracts are documented (TypeBox + generated OpenAPI) and implementations conform, or discrepancies are named. Breaking changes are identified before merge.
+
+## Agent Prompt
+
+Apply API First to Basilic.
+
+Read architecture/api MDX, ADR 009, OpenAPI generation docs, TypeBox routes, `apps/api/openapi/openapi.json`, `@repo/core`, `@repo/react`, error catalog, CLI, and tests. Do not assume a hand-edited spec is correct.
+
+Source of truth is TypeBox on the route. OpenAPI and `@repo/core` are generated. Do not define a new authorization policy here. Do not widen into a public platform or GraphQL unless the product already is that.
+
+Propose the smallest useful boundary: one operation made explicit in TypeBox. Implement against the contract. Validate with generate + drift check and API tests. When behavior changes, regenerate OpenAPI and `@repo/core` in the same work. Update this instance when paths or checks change.
+
+## Notes
+
+**API vs Product:** Product names the capability and why it exists. API names how systems ask for it.
+
+**API vs Architecture:** Architecture decides which parts communicate. API defines the contract across that boundary.
+
+**API vs Data:** Data owns canonical domain meaning. API owns the consumer-facing representation.
+
+**API vs Security:** Security owns who may invoke a capability. API owns how that requirement, credentials, and denial appear at the boundary.
+
+**API vs Documentation:** TypeBox/OpenAPI is the contract. MDX explains why it looks that way.
+
+**Navigation:** [Generic spec](../principles/API.md) · [Human essay](../articles/API.md) · [Factory map](../ABOUT.md) · [API architecture](../../apps/docu/content/docs/architecture/api.mdx) · [OpenAPI generation](../../apps/docu/content/docs/development/openapi-generation.mdx)

--- a/_first/basilic/ARCHITECTURE.md
+++ b/_first/basilic/ARCHITECTURE.md
@@ -1,0 +1,98 @@
+# Architecture First
+
+## Principle
+
+Decide system boundaries, dependency direction, and deployment shape before local implementation choices harden into structural constraints.
+
+## Statement
+
+I treat architecture as the small set of decisions that are expensive to reverse: where responsibilities live, which dependencies point where, what crosses a process or trust boundary, and how the system is deployed. I do not design every class in advance. I make the consequential structure visible before the codebase makes it accidentally.
+
+## Outcome
+
+The system has an inspectable structural model at the level its scale requires. Components have named responsibilities and owners. Dependency direction, external systems, data stores, and deployment units are visible. Consequential choices have rationale and known tradeoffs. Implementation conforms, or the model is updated deliberately.
+
+## Artifacts
+
+- **Fact:** [`../../apps/docu/content/docs/architecture/index.mdx`](../../apps/docu/content/docs/architecture/index.mdx) — stack overview
+- **Fact:** [`../../apps/docu/content/docs/architecture/monorepo.mdx`](../../apps/docu/content/docs/architecture/monorepo.mdx) — apps vs packages
+- **Fact:** [`../../apps/docu/content/docs/adrs/`](../../apps/docu/content/docs/adrs/) — ADRs 001–011
+- **Fact:** Deployables: `apps/api` (system of record), `apps/web`, `apps/mobile` (UI scaffold), `apps/docu`
+- **Fact:** Packages: `core` (generated client), handwritten `react`, `ui`, `utils`, `error`, `cli`, `email`; `notif` unused
+- **Fact:** Apps depend on packages, never the reverse. `react` depends on `core`. Clients call Fastify over HTTP.
+- **Fact:** Store: PostgreSQL via `DATABASE_URL`. PGLite when `PGLITE=true`. Supabase is the managed host, not the auth SDK.
+- **Fact:** Externals: Vercel, Resend, OAuth IdPs, AI providers, Sentry/GlitchTip, EAS, scanners
+- **Drift:** Architecture index says “API as source of truth.” [api.mdx](../../apps/docu/content/docs/architecture/api.mdx) and [ADR 009](../../apps/docu/content/docs/adrs/009-api-architecture.mdx) say Fastify routes / TypeBox generate OpenAPI. Follow TypeBox/routes.
+- **Drift:** [portability.mdx](../../apps/docu/content/docs/architecture/portability.mdx) describes host-anywhere. Shipped path is Vercel + Supabase.
+- **Unresolved:** GCP/AWS as first-class deploy targets; mobile as an API consumer
+
+```mermaid
+flowchart LR
+  web[apps/web]
+  mobile[apps/mobile]
+  cli[packages/cli]
+  core[packages/core]
+  api[apps/api]
+  db[(PostgreSQL)]
+  web --> core
+  cli --> core
+  core -->|"HTTP"| api
+  api --> db
+  mobile -.->|"not wired"| core
+```
+
+## Minimum Useful Artifact
+
+- purpose: TypeScript fullstack starter (API, web, mobile, docs)
+- users: adopting developers; demo web users; CLI/agents with API keys
+- deployable units: Fastify API, Next.js web, Expo mobile, Fumadocs
+- data store: PostgreSQL (Drizzle in `apps/api`)
+- dependencies: clients → `@repo/core` → HTTP → Fastify/TypeBox → Drizzle
+- consequential decisions: ADRs 001 (monorepo), 002 (Fastify), 003 (Next), 004 (shadcn), 007/008 (Drizzle/Postgres), 009 (routes generate OpenAPI)
+
+## Recipe
+
+1. Inspect `apps/*`, `packages/*`, architecture MDX, ADRs, [`../../apps/docu/content/docs/deployment/`](../../apps/docu/content/docs/deployment/), Drizzle, and env.
+2. Understand product capabilities and quality attributes that constrain the structure.
+3. Identify accidental coupling (app-to-app imports, hand-edited OpenAPI, mobile pretending to be a client).
+4. Propose the smallest structural clarification or ADR. Prefer one boundary over a redesign.
+5. Record rationale, alternatives, consequences, and reconsideration trigger when consequential.
+6. Implement with apps → packages direction visible.
+7. Validate against code and deployment, not only the directory tree.
+8. Update architecture MDX and ADRs when structure changes; update this instance with paths.
+
+## Validation
+
+- A new contributor can name apps, packages, responsibilities, and dependency direction from architecture MDX.
+- Diagrams match code and deployment, or discrepancies are named (mobile, PostHog, portability).
+- New dependencies follow apps → packages; generated client from OpenAPI; no app-to-app imports.
+- Consequential choices have ADRs, not only a technology name.
+- Architecture stays proportional to a starter toolkit.
+
+## Definition of Done
+
+The structural decision is explicit, implemented, and validated. Boundaries and dependency direction are inspectable. Durable architecture artifacts match the system or record deliberate drift.
+
+## Agent Prompt
+
+Apply Architecture First to Basilic.
+
+Read `apps/docu/content/docs/architecture/`, ADRs 001–011, Turborepo layout, deployment MDX, Drizzle, and external integrations. Inspect implementation; do not assume diagrams are current.
+
+Treat Fastify route TypeBox as the HTTP contract source. OpenAPI is generated. Preserve intentional existing structure. Do not introduce services, layers, queues, or platforms because they are common elsewhere. Do not wire `apps/mobile` to `@repo/core` without a product decision.
+
+Propose the smallest useful structural change or ADR. Record rationale and tradeoffs. Validate against code and deployment. Update architecture MDX when structure changes. Update this instance when paths change.
+
+## Notes
+
+**Architecture vs Product:** Product names the capability and constraints. Architecture assigns responsibilities and structural boundaries.
+
+**Architecture vs Data:** Architecture places stores and data flows. Data owns canonical meaning, ownership, lifecycle, and evolution.
+
+**Architecture vs API:** Architecture decides which components communicate. API defines the contract across a boundary (TypeBox, then generated OpenAPI).
+
+**Architecture vs Pipelines:** Architecture describes deployment units and topology. Pipelines build, validate, and deliver them.
+
+**Architecture vs Operations:** Architecture names the running parts. Operations observes and recovers them.
+
+**Navigation:** [Generic spec](../principles/ARCHITECTURE.md) · [Human essay](../articles/ARCHITECTURE.md) · [Factory map](../ABOUT.md) · [Monorepo](../../apps/docu/content/docs/architecture/monorepo.mdx) · [API](../../apps/docu/content/docs/architecture/api.mdx)

--- a/_first/basilic/DATA.md
+++ b/_first/basilic/DATA.md
@@ -1,0 +1,84 @@
+# Data First
+
+## Principle
+
+Define canonical domain concepts, ownership, lifecycle, and change rules before stores, schemas, and events proliferate competing truths.
+
+## Statement
+
+I treat data as durable product state with meaning, ownership, and a lifecycle—not as columns left behind by features. Before several stores or consumers encode the same concept differently, I want to know what the concept means, which system is authoritative, how identity works, how it changes, how long it lives, and how it is removed.
+
+## Outcome
+
+Core domain concepts have shared names and definitions. Each important dataset has an owner and authoritative source. Identity, constraints, retention, deletion, lineage, and schema evolution are explicit at the level the product needs. Migrations preserve or deliberately transform meaning. Copies do not silently become competing sources of truth.
+
+## Artifacts
+
+- **Fact:** Owner is `apps/api` only. Schema: [`../../apps/api/src/db/schema/`](../../apps/api/src/db/schema/)
+- **Fact:** ADRs [007](../../apps/docu/content/docs/adrs/007-backend-orm.mdx) (Drizzle) and [008](../../apps/docu/content/docs/adrs/008-database.mdx) (Postgres)
+- **Fact:** Tables: `users`, `account`, `sessions`, `verification`, `auth_attempts`, `api_keys`, `wallet_identities`, `web3_nonce`, `web3_callback`, `passkey_credentials`, `passkey_challenges`, `passkey_auth_challenges`, `passkey_callback`, `totp`, `totp_setup`
+- **Fact:** `oauth_state` and `oauth_link_state` are `verification.type` values, not tables ([`verification.ts`](../../apps/api/src/db/schema/tables/verification.ts))
+- **Fact:** Sign-in methods: email, OAuth `account`, `wallet_identities`, `passkey_credentials`. TOTP is 2FA, not a sign-in method. Last-method guardrail on unlink.
+- **Fact:** Secrets at rest: API key and refresh `jti` via `hashToken`; magic-link/change-email codes HMAC-SHA256 with `ENCRYPTION_KEY`; OAuth tokens and web3/passkey callbacks AES-GCM
+- **Fact:** Migrations: [`../../apps/api/src/db/migrations/`](../../apps/api/src/db/migrations/) — generate from schema TypeScript; never hand-edit SQL
+- **Unresolved:** domain glossary; retention, deletion, residency; identity/dedup beyond PK uniqueness
+- **Unresolved:** PostHog as a derived copy — decided, not installed (Product)
+
+## Minimum Useful Artifact
+
+For `users` (and the same shape for any concept you touch):
+
+- name: user identity for sessions and linking
+- identity: text primary key; email nullable (Web3-only accounts)
+- owner: Fastify API / PostgreSQL
+- writers: auth and account routes; readers: JWT session load, profile, `@repo/core` clients over HTTP
+- derived copies: none shipped (PostHog unmeasured)
+- retention/deletion: **unresolved**
+- evolution: Drizzle migrations under `apps/api/src/db/migrations/`
+
+## Recipe
+
+1. Inspect `apps/api/src/db/schema/`, migrations, auth/account handlers, analytics docs, and caches.
+2. Understand where each concept is created, changed, copied, and deleted.
+3. Identify competing definitions, unclear ownership, or extra tables invented from prose.
+4. Propose the smallest useful clarification—one concept, constraint, or migration rule.
+5. Define canonical meaning in Drizzle before adding a store or OpenAPI-only field.
+6. Implement with `drizzle-kit generate`. Do not edit generated SQL as a parallel schema.
+7. Validate read/write paths and deletion/unlink behavior (last-method guardrail).
+8. Update ADRs or schema comments when meaning, ownership, or lifecycle changes; update this instance.
+
+## Validation
+
+- A contributor can name PostgreSQL via Drizzle as authoritative for account and session data.
+- Core concepts have one meaning in tables and TypeBox representations.
+- Domain invariants are enforced in DB constraints and TypeBox, not comments alone.
+- Schema changes include a generated migration and rollback/recovery reasoning.
+- Retention and deletion match Security and product requirements, or are marked unresolved.
+
+## Definition of Done
+
+The affected domain concepts, ownership, invariants, lifecycle, and evolution rules are explicit. Implementations and migrations preserve them, or deliberate transformations and unresolved risks are documented.
+
+## Agent Prompt
+
+Apply Data First to Basilic.
+
+Read ADR 007/008, `apps/api/src/db/schema/`, migrations, and handlers that read and write them. Trace data from creation through copies and deletion. Do not assume the schema is the whole domain model. Do not invent tables for `oauth_state` — they are verification types.
+
+Preserve intentional existing models. Do not introduce a warehouse, event bus, or new source of truth. Propose the smallest useful data decision. Implement with Drizzle generate. Validate real read/write paths where safe. Update durable artifacts when meaning, ownership, lifecycle, or schema changes. Update this instance when paths change.
+
+## Notes
+
+**Data vs Product:** Product owns event taxonomy and outcomes to measure. Data owns meaning, authority, and lifecycle of records.
+
+**Data vs Architecture:** Architecture places stores and data flows. Data defines what the state means and which source is authoritative.
+
+**Data vs API:** Data owns the canonical domain model. API owns the consumer-facing representation.
+
+**Data vs Security:** Data records classification, retention, and deletion requirements. Security owns access policy.
+
+**Data vs Quality:** Data owns domain invariants. Quality owns release gates and eval datasets.
+
+**Data vs Operations:** Data owns product state. Operations owns telemetry about runtime health.
+
+**Navigation:** [Generic spec](../principles/DATA.md) · [Human essay](../articles/DATA.md) · [Factory map](../ABOUT.md) · [ADR 008](../../apps/docu/content/docs/adrs/008-database.mdx)

--- a/_first/basilic/DESIGN.md
+++ b/_first/basilic/DESIGN.md
@@ -1,0 +1,69 @@
+# Design First
+
+## Principle
+
+Decide how the product behaves and communicates through its interface before layout and components become accidental consequences of implementation.
+
+## Statement
+
+Useful software is the floor. The product people remember is the one that feels clear, thoughtful, and enjoyable to use. I treat design as behavior, hierarchy, states, copy, and motion — not decoration bolted on at the end. Before I add a pattern, I look at what the project already has and reuse it. Invention is for when the problem actually needs it.
+
+## Outcome
+
+The interface follows a coherent design system: tokens, primitives, composition rules, and content patterns. Loading, empty, error, success, and disabled states are defined. New UI reuses established patterns. The agent-readable identity and the implementation agree, or the discrepancy is named. Browser verification across states is the bar.
+
+## Artifacts
+
+- **Fact:** No repo-root `DESIGN.md`. Do not invent a second palette to complete the template.
+- **Fact:** Tokens: [`../../packages/ui/src/styles/tokens.css`](../../packages/ui/src/styles/tokens.css) — semantic colors, sidebar, radius, `@theme inline`, Inter / Poppins / mono
+- **Fact:** Components: `@repo/ui` (shadcn/ui, Radix, Tailwind 4). ADR [004](../../apps/docu/content/docs/adrs/004-design-system.mdx). Frontend: [frontend.mdx](../../apps/docu/content/docs/architecture/frontend.mdx)
+- **Fact:** Apps consume `@repo/ui`; app-only UI collocated in `apps/web` / `apps/mobile` / `apps/docu`
+- **Fact:** Skills: `shadcn-v3`, `tailwind-design-system-v4`, `frontend-design-v1`; playbook `/audit-accessibility`, `/use-shadcn`
+- **Unresolved:** agent-readable `DESIGN.md`; motion guidelines; copy patterns beyond component defaults
+
+## Minimum Useful Artifact
+
+- user goal and states: per feature (default, loading, empty, error, success, disabled)
+- reuse: `@repo/ui` + `tokens.css`
+- interaction: follow adjacent screens; do not introduce hex or typefaces outside tokens
+- a11y: keyboard, contrast, focus, `prefers-reduced-motion` via `/audit-accessibility`
+- verification: browser across states — not a single default screenshot
+
+## Recipe
+
+1. Inspect ADR 004, frontend MDX, `packages/ui`, `tokens.css`, and adjacent screens. There is no `DESIGN.md`.
+2. Understand required states for the feature.
+3. Identify missing states or values outside the system.
+4. Propose primitives from `@repo/ui`. New components only when nothing fits (`/use-shadcn`).
+5. Define click, submit, dismiss, back. Motion only for feedback.
+6. Implement with existing primitives. No parallel palette.
+7. Validate in the browser across states, keyboard, and reduced motion.
+8. Update `@repo/ui` or MDX if you introduced a reusable pattern; update this instance.
+
+## Validation
+
+- New UI uses existing tokens and `@repo/ui` unless a gap is documented.
+- Tokens in CSS and usage agree. No second palette. Absent `DESIGN.md` is named, not silently filled.
+- Required states render and behave.
+- Motion respects `prefers-reduced-motion`.
+- A screenshot of the default view is not verification.
+
+## Definition of Done
+
+Interface behavior matches design intent. States are handled. Patterns are reusable or documented. Tokens in CSS are the system of record until a `DESIGN.md` exists.
+
+## Agent Prompt
+
+Apply Design First to Basilic.
+
+Read ADR 004, frontend MDX, `packages/ui`, and `packages/ui/src/styles/tokens.css` before building UI. There is no repo `DESIGN.md` — do not create a second palette.
+
+Reuse `@repo/ui`. Do not invent components, hex values, or typefaces without checking the system. Define loading, empty, error, and success states. Validate in the browser across states. Update durable design artifacts when patterns change. Update this instance when paths change.
+
+## Notes
+
+**Design vs Journeys:** Journeys define what happens. Design defines how the interface expresses it.
+
+**Design vs API:** API is the capability boundary. Design is the human-visible expression. `DESIGN.md` is an artifact, not the principle.
+
+**Navigation:** [Generic spec](../principles/DESIGN.md) · [Human essay](../articles/DESIGN.md) · [Factory map](../ABOUT.md) · [Frontend](../../apps/docu/content/docs/architecture/frontend.mdx) · [ADR 004](../../apps/docu/content/docs/adrs/004-design-system.mdx)

--- a/_first/basilic/DOCUMENTATION.md
+++ b/_first/basilic/DOCUMENTATION.md
@@ -1,0 +1,71 @@
+# Documentation First
+
+## Principle
+
+Keep the context future humans and agents need to decide well in durable project files, not in conversations that disappear.
+
+## Statement
+
+I document decisions and context, not obvious code. If someone will need to rediscover it, explain it twice, or guess why we chose this, it belongs in a file. Chat is for coordination. Files are the system of record. Wrong docs are worse than no docs.
+
+## Outcome
+
+Consequential decisions, conventions, setup steps, and domain context live in discoverable project files. Documentation matches current behavior or explicitly notes drift. When behavior or assumptions change, the files change in the same work.
+
+## Artifacts
+
+- **Fact:** Canonical: [`../../apps/docu/content/docs/`](../../apps/docu/content/docs/) — architecture, ADRs, development, testing, deployment
+- **Fact:** How to run: [`../../README.md`](../../README.md) and app/package READMEs — link to docs, no duplication ([docs.mdc](../../.cursor/rules/base/docs.mdc))
+- **Fact:** Agents: [`../../AGENTS.md`](../../AGENTS.md); constraints `.cursor/rules/`; skills `.agents/skills/`
+- **Fact:** Workflow index: [ai-workflow.mdx](../../apps/docu/content/docs/development/ai-workflow.mdx)
+- **Fact:** Public LLM indexes: `/llms.txt`, `/llms-full.txt` on the docs site
+- **Fact:** Portable factory: `../` (ABOUT, principles, articles). This folder is the adoption pack, not a second docs site.
+- **Fact:** Same-change rule: update matching MDX when behavior, commands, or conventions change
+- **Drift:** named in sibling instances (PostHog, “API as source of truth”, portability vs Vercel). Fix MDX in the same work when you change the fact; do not leave load-bearing drift only in chat.
+
+## Minimum Useful Artifact
+
+- reader: future human or agent on this task
+- canonical location: usually `apps/docu/content/docs/…`; README points there
+- decision or procedure that cannot be inferred safely
+- implementation links
+- trigger for next review: the same PR that changes behavior
+
+## Recipe
+
+1. Inspect READMEs, `AGENTS.md`, Fumadocs MDX, ADRs, rules, and skills.
+2. Compare those files to implementation. Flag contradictions.
+3. Identify missing decisions, constraints, setup, domain rules.
+4. Propose the smallest useful doc — ADR, MDX section, README pointer.
+5. Write it in `apps/docu` (or the collocated README). One canonical source.
+6. Update docs in the same change if behavior or assumptions changed.
+7. Remove or archive docs that are wrong.
+8. Validate that a new contributor can set up and orient from files without asking in chat.
+
+## Validation
+
+- A new contributor can set up and orient from README + docs without asking in chat.
+- ADRs exist for consequential architectural decisions, or the decision is deferred.
+- Agent instructions reflect how the project works today.
+- Chat is not the system of record.
+- Generic FIRST files stay free of this repo’s product paths.
+
+## Definition of Done
+
+Durable context is written, accurate, and discoverable. Documentation drift is resolved or explicitly tracked. Future work will not need to rediscover what was already decided.
+
+## Agent Prompt
+
+Apply Documentation First to Basilic.
+
+Read root README, `AGENTS.md`, `apps/docu/content/docs/`, ADRs, and `.cursor/rules` before acting. Compare documentation to implementation.
+
+Document decisions and conventions — not obvious code. Propose the smallest useful MDX or README update. When you change behavior, update durable files in the same work. Do not leave load-bearing decisions only in chat. Do not encode this repo’s product facts in `../principles/` or `../ABOUT.md`.
+
+## Notes
+
+**Documentation vs everything:** Other stations produce decisions. Documentation decides which context must stay durable.
+
+**Documentation vs Workflow:** Workflow determines when context is created. Documentation preserves it.
+
+**Navigation:** [Generic spec](../principles/DOCUMENTATION.md) · [Human essay](../articles/DOCUMENTATION.md) · [Factory map](../ABOUT.md) · [AI workflow](../../apps/docu/content/docs/development/ai-workflow.mdx)

--- a/_first/basilic/JOURNEYS.md
+++ b/_first/basilic/JOURNEYS.md
@@ -19,7 +19,7 @@ Actors, entry points, happy paths, alternates, error paths, permission gates, an
 - **Fact:** Actors: web end user; adopting developer; CLI/agent with API key; CI/CodeRabbit/DeepSec; mobile user (**deferred**)
 - **Fact:** Login methods: magic link (`token`+`verificationId` or `token`+`email`); OAuth GitHub/Google/Facebook/Twitter; passkey; Web3 EIP-155/Solana on the API. TOTP is 2FA only.
 - **Fact:** E2E magic link: `test@test.ai` when `ALLOW_TEST=true`
-- **Fact:** Session: access/refresh JWT, CAS rotation, `TOKEN_REUSE_DETECTED`, logout **204**. API keys cannot logout — `USE_KEY_REVOKE`. Cookie `api.session` (`httpOnly: false` — Security names the risk).
+- **Fact:** Session: access/refresh JWT, CAS rotation, `TOKEN_REUSE_DETECTED`, logout **204**. API keys cannot log out — `USE_KEY_REVOKE`. Cookie `api.session` (`httpOnly: false` — Security names the risk).
 - **Fact:** Account: last-method guardrail (`LAST_SIGN_IN_METHOD`); change/link email; OAuth/wallet/passkey link; API keys `bask_` shown once.
 - **Fact:** CLI: API key only; JWT auth endpoints excluded ([cli.mdx](../../apps/docu/content/docs/development/cli.mdx))
 - **Drift:** Web3 verify exists on Fastify; **web has no wallet UI**. Do not map a wallet-connect journey as shipped.

--- a/_first/basilic/JOURNEYS.md
+++ b/_first/basilic/JOURNEYS.md
@@ -1,0 +1,93 @@
+# Journeys First
+
+## Principle
+
+Map how someone finishes a job — including errors, permissions, and state — before implementation invents the path from whichever screen shipped first.
+
+## Statement
+
+The product is not a collection of screens. It is someone trying to finish a job. I map that job from entry to completion before I trust implementation to fill in the gaps. Happy paths are cheap. The product breaks in the alternates: the error nobody designed, the permission that exists on one route but not another, the state with no exit.
+
+## Outcome
+
+Actors, entry points, happy paths, alternates, error paths, permission gates, and completion criteria are documented or explicitly marked unknown. Missing states are visible before code hardens around an incomplete model.
+
+## Artifacts
+
+- **Fact:** [authentication.mdx](../../apps/docu/content/docs/architecture/authentication.mdx), [account-linking.mdx](../../apps/docu/content/docs/architecture/account-linking.mdx)
+- **Fact:** Web gate: [`../../apps/web/proxy.ts`](../../apps/web/proxy.ts). Public: `/auth/login`, `/auth/callback/*`, `/auth/logout`, `/terms`, `/privacy`, `/images/auth-login-hero.webp`. Unauthenticated → login. Authenticated on login → `/`. Token refresh on navigation.
+- **Fact:** Actors: web end user; adopting developer; CLI/agent with API key; CI/CodeRabbit/DeepSec; mobile user (**deferred**)
+- **Fact:** Login methods: magic link (`token`+`verificationId` or `token`+`email`); OAuth GitHub/Google/Facebook/Twitter; passkey; Web3 EIP-155/Solana on the API. TOTP is 2FA only.
+- **Fact:** E2E magic link: `test@test.ai` when `ALLOW_TEST=true`
+- **Fact:** Session: access/refresh JWT, CAS rotation, `TOKEN_REUSE_DETECTED`, logout **204**. API keys cannot logout — `USE_KEY_REVOKE`. Cookie `api.session` (`httpOnly: false` — Security names the risk).
+- **Fact:** Account: last-method guardrail (`LAST_SIGN_IN_METHOD`); change/link email; OAuth/wallet/passkey link; API keys `bask_` shown once.
+- **Fact:** CLI: API key only; JWT auth endpoints excluded ([cli.mdx](../../apps/docu/content/docs/development/cli.mdx))
+- **Drift:** Web3 verify exists on Fastify; **web has no wallet UI**. Do not map a wallet-connect journey as shipped.
+- **Unresolved:** named journey files beyond auth MDX; mobile completion; in-product AI assistant as a mapped job (chat chrome exists)
+
+```mermaid
+stateDiagram-v2
+  unauth[Unauthenticated]
+  authn[Authenticated]
+  refresh[Refreshing]
+  unauth --> authn: login callback sets cookie
+  authn --> authn: Bearer API calls
+  authn --> refresh: 401 or expired access
+  refresh --> authn: refresh OK
+  refresh --> unauth: refresh fail
+  authn --> unauth: logout or revoked
+```
+
+## Minimum Useful Artifact
+
+- actor: web end user
+- job: sign in and reach `/`
+- entry: `/auth/login`
+- happy path: magic link or OAuth or passkey → callback sets cookies → `/`
+- alternates: code entry vs link click; OAuth 503 if provider unconfigured
+- errors: invalid/expired codes, `TOKEN_REUSE_DETECTED`, `SESSION_NOT_FOUND`
+- gates: proxy (web) and Fastify JWT/API key — policy in SECURITY.md
+- completion: authenticated session; home loads. Wallet link after login is optional, not required.
+
+## Recipe
+
+1. Inspect authentication and account-linking MDX, `apps/web/proxy.ts`, Fastify auth/account routes, web pages, CLI.
+2. Understand the actor and the job — not the screen.
+3. Identify missing error exits, permission drift across web/API/CLI, states with no resume.
+4. Propose the smallest useful map: one job, entries, gates, completion.
+5. Write happy path, then alternates, then errors, then permission gates.
+6. Compare the map to implementation. Flag Web3-without-UI and mobile as deferrals.
+7. Validate every mapped state traces to code or an explicit deferral.
+8. Update auth MDX when flow behavior changes; update this instance.
+
+## Validation
+
+- Critical flows have defined error and recovery (refresh fail → login; reuse → revoke).
+- Permission checks are consistent across proxy, Fastify, and CLI exclusions.
+- Every mapped state traces to implemented behavior or an explicit deferral (mobile, wallet UI).
+
+## Definition of Done
+
+Critical flows are mapped with happy, alternate, and error paths documented or explicitly deferred. Implementation matches the map, or the map was updated to reflect a deliberate change.
+
+## Agent Prompt
+
+Apply Journeys First to Basilic.
+
+Read authentication and account-linking MDX, `apps/web/proxy.ts`, Fastify auth/account routes, web auth UI, CLI, and tests. Map actors, entry points, states, errors, and completion. Compare documentation to actual behavior.
+
+Do not invent UI (including wallet connect). Do not invent a mobile journey. Surface missing states before implementing. Policy stays in Security. Propose the smallest useful update to journey artifacts in `apps/docu`. Update this instance when flows change.
+
+Treat CLI and coding agents as actors. If an actor is unnamed, do not invent a tool for them.
+
+## Notes
+
+**Journeys vs Product:** Product answers what and why. Journeys answer how someone finishes.
+
+**Journeys vs Design:** Journeys describe behavior and flow. Design describes how the interface expresses it.
+
+**Journeys vs Security:** Journeys show where a permission gate occurs. Security owns the permission policy.
+
+**Journeys vs Data:** Journeys describe actor-visible states. Data owns persisted meaning and lifecycle.
+
+**Navigation:** [Generic spec](../principles/JOURNEYS.md) · [Human essay](../articles/JOURNEYS.md) · [Factory map](../ABOUT.md) · [Authentication](../../apps/docu/content/docs/architecture/authentication.mdx) · [Account linking](../../apps/docu/content/docs/architecture/account-linking.mdx)

--- a/_first/basilic/OPERATIONS.md
+++ b/_first/basilic/OPERATIONS.md
@@ -1,0 +1,78 @@
+# Operations First
+
+## Principle
+
+Decide how you will see, support, and recover the running system before production becomes a black box.
+
+## Statement
+
+Shipping is not the end of engineering work. It is when the system meets reality. I want to know what it is doing, what failed, for whom, and how to fix it — without archaeology. A product nobody can operate is a product that will fail quietly.
+
+## Outcome
+
+Production behavior is observable at the level the project needs. Logs are structured and useful. Metrics and alerts cover critical failure modes. Runbooks exist for known recovery paths. Product analytics are not the same dashboard as engineering health. A green pipeline after a fix is not verified recovery.
+
+## Artifacts
+
+- **Fact:** [logging.mdx](../../apps/docu/content/docs/architecture/logging.mdx) — Pino `@repo/utils/logger/server` and `/client`. Routes use `request.log`. Secrets redacted. Never `console.*` in app code.
+- **Fact:** [error-handling.mdx](../../apps/docu/content/docs/architecture/error-handling.mdx) — `@repo/error` + Sentry/GlitchTip; HTTP catalog `{ code, message }`
+- **Fact:** `GET /health` → `{ ok: true, dbReady }` — no auth, no deep probes (Resend/AI/IdP)
+- **Fact:** Deploy: [vercel.mdx](../../apps/docu/content/docs/deployment/vercel.mdx), [self-hosted-llm.mdx](../../apps/docu/content/docs/deployment/self-hosted-llm.mdx)
+- **Fact:** Rate limits are in-memory per API instance (Security names the policy; this station names the multi-replica blind spot)
+- **Unresolved:** dashboards and alert rules; runbooks; request-id join-key standard for operators; verify-in-the-running-system after deploy
+- **Unresolved:** production identity/retries for in-product AI agents
+
+PostHog is Product, not operations. Do not file a missing success event as an ops ticket.
+
+## Minimum Useful Artifact
+
+- critical path: auth and API 500s that strand a user
+- signal: Pino `request.log`; Sentry/GlitchTip; `/health`
+- join key: **unresolved** as a named operator standard
+- alert/owner/escalation: **unresolved**
+- recovery: **unresolved** as runbooks
+- verify: **unresolved** (CI green is not this)
+
+## Recipe
+
+1. Inspect logging MDX, error-handling MDX, `/health`, Sentry init, deploy docs.
+2. Understand critical failure modes and who notices first.
+3. Identify a 500 with no useful log, a deploy that cannot be verified.
+4. Propose the smallest useful signal — one log field, one metric, one alert.
+5. Write a runbook only for paths that have burned time.
+6. Implement. Do not invent product events (Product).
+7. Route production bugs through workflow: issue → fix → pipeline → verify in the running system.
+8. Update operational MDX when behavior or failure modes change; update this instance.
+
+## Validation
+
+- A developer can diagnose a common failure from Pino or Sentry without guessing.
+- Alerts fire on real problems, or alerts are marked unresolved.
+- Recovery steps are documented and exercised, or marked unresolved.
+- Post-fix deploy was verified in production or staging. CI green is not that verification.
+
+## Definition of Done
+
+Runtime behavior is observable enough to support and debug. Recovery paths are known. Production feedback can enter the development workflow and close the loop.
+
+## Agent Prompt
+
+Apply Operations First to Basilic.
+
+Read logging and error-handling MDX, `/health`, `@repo/error` / Sentry usage, and deployment docs before changing runtime behavior. Identify observability blind spots.
+
+Propose the smallest useful logging, metric, or alert improvement. Use structured signals — not `console`. Route fixes through workflow and pipelines. Verify recovery after deploy in the running system. Do not file PostHog gaps as ops. Update this instance when paths change.
+
+## Notes
+
+**Operations vs Pipelines:** Pipelines move changes into production. Operations understands and runs the system after deployment.
+
+**Operations vs Security:** Security defines trust and protection. Operations defines visibility and recovery.
+
+**Operations vs Product:** Product owns whether the bet is working. Operations owns whether the system is healthy.
+
+**Operations vs Architecture:** Architecture names deployment units. Operations observes and recovers them.
+
+**Operations vs Data:** Data owns product-state meaning. Operations owns telemetry about runtime health.
+
+**Navigation:** [Generic spec](../principles/OPERATIONS.md) · [Human essay](../articles/OPERATIONS.md) · [Factory map](../ABOUT.md) · [Logging](../../apps/docu/content/docs/architecture/logging.mdx) · [Error handling](../../apps/docu/content/docs/architecture/error-handling.mdx)

--- a/_first/basilic/PIPELINES.md
+++ b/_first/basilic/PIPELINES.md
@@ -1,0 +1,75 @@
+# Pipelines First
+
+## Principle
+
+Treat automated validation and delivery as part of the development feedback loop — including the agent feedback loop — not as a ritual after the real work.
+
+## Statement
+
+A change is not done when it compiles on my machine. It is done when it passes the same checks everyone else relies on, and when it can reach the environment it needs to reach. For agents, CI is ground truth: implement, run checks, read failures, fix or escalate, run again. I keep the path from source to deployable explicit at the level the project actually needs.
+
+## Outcome
+
+Changes flow through an automated path: format → lint → typecheck → test → build → preview (if applicable) → deploy → verify. The commit stage builds the artifact once. Later stages promote that artifact; they do not rebuild a different one per environment. Agents can interpret CI failure output and act.
+
+## Artifacts
+
+- **Fact:** [github-actions.mdx](../../apps/docu/content/docs/deployment/github-actions.mdx)
+- **Fact:** [`.github/workflows/lint.yml`](../../.github/workflows/lint.yml) — Biome/ESLint/types plus `_first` docs validation
+- **Fact:** [`.github/workflows/security.yml`](../../.github/workflows/security.yml), [`.github/workflows/deepsec.yml`](../../.github/workflows/deepsec.yml)
+- **Fact:** Path-filtered: `api-e2e.yml` (OpenAPI drift + cov), `web-e2e.yml`, `packages-test.yml`
+- **Fact:** Mobile: `mobile-build.yml`, `mobile-preview.yml`, `mobile-pr-preview.yml` ([mobile-cicd.mdx](../../apps/docu/content/docs/deployment/mobile-cicd.mdx))
+- **Fact:** Local: `pnpm qa` via [`../../scripts/run-qa.mjs`](../../scripts/run-qa.mjs) — checktypes → lint → generate + drift → build → unit → e2e (`SKIP_BUILD=1`)
+- **Fact:** Vercel git deploys web/api/docu ([vercel.mdx](../../apps/docu/content/docs/deployment/vercel.mdx)). CI does **not** deploy. Preview migrate gated unless `RUN_PG_MIGRATE=true`.
+- **Fact:** `web-e2e` needs `ANTHROPIC_API_KEY`. FIRST validator: `python3 _first/scripts/validate_docs.py`
+- **Unresolved:** commit-stage artifact identity and promote-without-rebuild (hosts rebuild from git)
+
+## Minimum Useful Artifact
+
+- triggers: every PR for lint/security; path filters for e2e/packages; EAS on mobile paths
+- local mirror: `pnpm qa`, `pnpm lint`, `pnpm checktypes`
+- artifact: **unresolved** (git SHA on Vercel/EAS)
+- promotion: preview on PR, prod on main — rebuild, not promote
+- failures: `gh pr checks` / `gh run view` (`/fix-github-actions`); never GitHub MCP for Actions logs
+
+## Recipe
+
+1. Inspect `.github/workflows/`, `turbo.json`, deployment MDX, `pnpm qa`.
+2. Understand path from change to Vercel/EAS/API host.
+3. Identify missing checks, flaky jobs, unreadable logs.
+4. Propose the smallest pipeline improvement.
+5. Implement. Prefer existing `pnpm` scripts.
+6. Verify locally with the same commands CI uses when possible.
+7. Read CI output with `gh`. Fix or escalate.
+8. Document deploy steps in deployment MDX if they changed.
+
+## Validation
+
+- CI passes on the change branch.
+- Local `pnpm qa` / targeted scripts catch the same class of failure.
+- A green agent sandbox is not GitHub Actions.
+- Deploy path is documented. Promote-without-rebuild is unresolved, not pretended.
+
+## Definition of Done
+
+The change is validated by automated pipelines and is deployable through the project's defined path. Pipeline config is updated if new checks were added.
+
+## Agent Prompt
+
+Apply Pipelines First to Basilic.
+
+Read `.github/workflows/`, `turbo.json`, deployment MDX, and root README scripts before changing delivery. Use existing commands — `pnpm qa` when the change warrants it.
+
+When implementation completes, ensure CI would pass. Read failures with `gh` (not GitHub MCP). Do not treat a green local sandbox as the pipeline. Distinguish pipeline failures from quality criteria. Update deployment docs when delivery changes. Update this instance when workflows or commands change.
+
+## Notes
+
+**Pipelines vs Workflow:** Pipelines automate validation and delivery. Workflow defines how humans and agents respond.
+
+**Pipelines vs Architecture:** Architecture defines deployment units. Pipelines build and deliver them.
+
+**Pipelines vs Quality:** Quality names the bar. Pipelines run it.
+
+**Pipelines vs Operations:** Pipelines get changes into production. Operations runs what arrived.
+
+**Navigation:** [Generic spec](../principles/PIPELINES.md) · [Human essay](../articles/PIPELINES.md) · [Factory map](../ABOUT.md) · [GitHub Actions](../../apps/docu/content/docs/deployment/github-actions.mdx)

--- a/_first/basilic/PRODUCT.md
+++ b/_first/basilic/PRODUCT.md
@@ -1,0 +1,82 @@
+# Product First
+
+## Principle
+
+Define what you are building, for whom, why it is worth building, and how you will know — before implementation becomes the specification.
+
+## Statement
+
+I do not let the codebase become the product brief. Before I change meaningful behavior, I want a file that names the problem, who has it, why it is worth building, what we are not building, how it reaches people, and how we will know. Implementation can reveal a better option. It should not invent the goal.
+
+## Outcome
+
+The project has an inspectable answer to what, why, and how we will know. Non-goals, GTM, success metrics, and the tracking plan are written or explicitly unresolved. Named metrics have events, or are marked unmeasured. When the product is a business, market size and unit economics are stated as measured or as hypotheses.
+
+## Artifacts
+
+- **Fact:** [`../../README.md`](../../README.md) — API-first TypeScript fullstack starter (Fastify, OpenAPI, Next, Expo)
+- **Fact:** [`../../apps/docu/content/docs/index.mdx`](../../apps/docu/content/docs/index.mdx) — toolkit intro
+- **Fact:** Two audiences: **adopters** (developers using the starter) and **demo users** (web news `/`, markets, settings, in-shell assistant; auth is the shipped job)
+- **Fact:** Not a billed SaaS in files. No `PRODUCT.md` / PRD. Do not invent one to fill TAM.
+- **Fact:** Observed non-goals in code/docs: mobile not an API client; no web wallet UI; `@repo/notif` unused; Cache Components off; `@repo/react` hooks handwritten
+- **Drift:** PostHog **decided** ([ADR 011](../../apps/docu/content/docs/adrs/011-product-analytics.mdx), [analytics.mdx](../../apps/docu/content/docs/architecture/analytics.mdx)) but **not installed**. ADR still mentions `@vercel/analytics` — neither package is in web/mobile `package.json`. Event taxonomy **unmeasured**.
+- **Unresolved:** GTM (channel, first successful use); success metrics that can fail (not `pnpm qa`); TAM/LTV (toolkit — say so); named decision owners for the product bet
+- **Unresolved:** keep / iterate / kill board
+
+`pnpm qa` going green is Quality/Pipelines, not product success.
+
+## Minimum Useful Artifact
+
+- problem: bootstrap a typed API + web/mobile/docs without inventing the stack
+- users: adopting developers (inferred); demo end users on web auth and dashboard
+- goal: portable starter with self-hosted Web2/Web3 auth and Cursor-first workflow
+- non-goals: listed above as observed, not a ratified PRD
+- audience/channel/first use: **unresolved** beyond “fork and run”
+- metrics: **unmeasured**
+- events: **unmeasured** (PostHog chosen, not shipped)
+- owners: **unresolved**
+
+## Recipe
+
+1. Inspect README, docs index, analytics ADR, issues, running web/API, and claimed metrics.
+2. Understand shipped vs claimed (starter vs product, GTM, measurement).
+3. Identify missing users, missing goal, success that cannot fail, named metrics with no events.
+4. Propose the smallest useful update to a durable product artifact in `apps/docu` or README — not a parallel fake PRD.
+5. Make decisions explicit, or name them unresolved. Do not hide them in code.
+6. When a change can move a metric, ship the event in the same work — or mark unmeasured.
+7. After use, compare metric to target and record keep / iterate / kill — when metrics exist.
+8. Update durable artifacts and this instance if the bet, GTM, or analytics changed.
+
+## Validation
+
+- A new contributor can answer what we are building from README + this file: a starter/toolkit with a demo web app. Who/why/how-we-will-know beyond that is unresolved.
+- Success metrics can fail. They are not CI green. Currently unmeasured.
+- Named metrics have events, or are marked unmeasured (PostHog).
+- GTM is named at the level the product needs, or marked unresolved.
+- No silent product decisions in code without a note or open question.
+
+## Definition of Done
+
+Product intent is documented or explicitly deferred with named owners. Implementation aligns with stated goals and non-goals, or the docs were updated. Success that was claimed is either instrumented or marked unmeasured.
+
+## Agent Prompt
+
+Apply Product First to Basilic.
+
+Read root README, `apps/docu/content/docs/index.mdx`, analytics MDX and ADR 011, and what the web, mobile, and API actually do. Do not assume documentation is complete. PostHog is not installed — do not claim events fire.
+
+Preserve intentional existing product choices. Do not silently decide scope, priorities, pricing, TAM, LTV, event names, or GTM. This is a toolkit, not a billed product in files — say so rather than filling finance blanks.
+
+Separate `pnpm qa` from post-launch success. If a metric is named but not instrumented, implement the event or mark it unmeasured. Do not file that as operations work. Propose the smallest useful update to README or `apps/docu`. Update this instance when paths or unresolved items change.
+
+## Notes
+
+**Product vs Journeys:** Product names what, why, and how we will know. Journeys name how someone finishes.
+
+**Product vs Quality:** Product names the outcome after use. Quality names the bar that gates a release.
+
+**Product vs Operations:** Product owns events, funnels, activation. Operations owns logs, traces, error rates, alerts, recovery.
+
+**Product vs Data:** Product names events and outcomes to measure. Data owns canonical domain meaning, authority, lifecycle, and evolution.
+
+**Navigation:** [Generic spec](../principles/PRODUCT.md) · [Human essay](../articles/PRODUCT.md) · [Factory map](../ABOUT.md) · [Introduction](../../apps/docu/content/docs/index.mdx) · [ADR 011](../../apps/docu/content/docs/adrs/011-product-analytics.mdx)

--- a/_first/basilic/QUALITY.md
+++ b/_first/basilic/QUALITY.md
@@ -1,0 +1,74 @@
+# Quality First
+
+## Principle
+
+Name what good means — acceptance, tests, evals, performance — before anyone optimizes toward an undefined target.
+
+## Statement
+
+I do not ask anyone to "make it better" without saying what better means. Tests prove deterministic behavior. Evals cover probabilistic output. Performance budgets beat vibes. Name the bar before you optimize, or you ship something that looks done and still fails users.
+
+## Outcome
+
+Acceptance criteria exist for features that matter. Tests protect critical paths. AI features with probabilistic output have evals where appropriate. Performance-sensitive areas have budgets. Humans and agents know what done means beyond "it compiles."
+
+## Artifacts
+
+- **Fact:** [testing/index.mdx](../../apps/docu/content/docs/testing/index.mdx), [e2e-testing.mdx](../../apps/docu/content/docs/testing/e2e-testing.mdx)
+- **Fact:** API: Vitest + `fastify.inject()`, group `*.spec.ts` imports `*.test.ts`, PGLite, serial workers, orphan import check
+- **Fact:** Packages: Vitest for `core`, `react`, `error`
+- **Fact:** Web: Playwright only (no frontend unit suite). Maestro deferred in CI.
+- **Fact:** One HTTP status per `inject()`; catalog `{ code, message }`; `BAD_REQUEST` on schema 400
+- **Fact:** AI: contract tests hard; remote may `ctx.skip()` when key missing or 402 — never return early without skip (soft-pass forbidden). With real key, 502/503/504 fail.
+- **Fact:** Coverage: `pnpm --filter @repo/api test:cov` uploaded; **no floors** in CI
+- **Fact:** Playbooks: `write-api-test`, `write-unit-tests`, `use-tdd`, `run-all-tests-and-fix`
+- **Unresolved:** named release bar beyond “CI green”; eval datasets for `/ai/chat` and `/ai/generate`; performance budgets; visual regression
+
+## Minimum Useful Artifact
+
+- risk: auth, health, catalog errors, OpenAPI drift
+- criterion: API test or Playwright spec asserting behavior
+- eval/budget: **unresolved** for probabilistic AI and perf
+- command: `pnpm --filter @repo/api test:unit`, `pnpm test:e2e`
+- on fail: fix or escalate; do not skip remote AI without `ctx.skip()`
+
+## Recipe
+
+1. Inspect testing MDX, existing Vitest/Playwright, and CI quality jobs.
+2. Understand what “good” means for this change.
+3. Identify unprotected critical paths or AI without evals.
+4. Propose the smallest useful quality artifact before or alongside implementation.
+5. Write criteria that assert behavior. API: one status per `inject()`.
+6. Run existing validation — do not invent a parallel suite.
+7. Fix failures or escalate when the bar needs a product decision.
+8. Update testing MDX when criteria change; update this instance.
+
+## Validation
+
+- Acceptance criteria are testable or demonstrable.
+- Critical paths have automated protection where the project supports it.
+- Failures produce actionable signal.
+- AI evals cover user-dependent behaviors, or are marked unresolved (skip is not a pass).
+- CI going green is Pipelines. Meeting the bar is Quality.
+
+## Definition of Done
+
+Stated quality criteria are met and verified by the project's existing validation. Regressions are caught or explicitly accepted with documented rationale.
+
+## Agent Prompt
+
+Apply Quality First to Basilic.
+
+Read `apps/docu/content/docs/testing/`, existing `*.spec.ts` / Playwright specs, and CI gates before implementing. Define what “good” means for this change.
+
+Write or update tests alongside implementation. Use existing commands. For `/ai/*`, do not treat a wrapper unit test as an eval. Never soft-pass remote AI tests. Preserve group-entry and catalog-error patterns. Fix failures or escalate. Update testing docs when criteria change. Update this instance when commands change.
+
+## Notes
+
+**Quality vs Pipelines:** Quality defines what should be validated. Pipelines run the validation.
+
+**Quality vs Product:** Product defines success after use. Quality defines the bar that gates a release.
+
+**Quality vs Data:** Data owns domain invariants. Quality owns release gates and eval datasets.
+
+**Navigation:** [Generic spec](../principles/QUALITY.md) · [Human essay](../articles/QUALITY.md) · [Factory map](../ABOUT.md) · [Testing](../../apps/docu/content/docs/testing/index.mdx)

--- a/_first/basilic/README.md
+++ b/_first/basilic/README.md
@@ -1,0 +1,63 @@
+# Basilic instances
+
+Operational specs for applying FIRST in this monorepo. Not a second factory. Durable facts live in `apps/docu/content/docs/`, ADRs, TypeBox routes, OpenAPI (generated), and package READMEs.
+
+This folder is this repository’s adoption pack. When copying FIRST into another repo, copy only `ABOUT.md` and `principles/` — skip this directory.
+
+## Load order
+
+1. [`../AGENTS.md`](../AGENTS.md)
+2. [`../ABOUT.md`](../ABOUT.md)
+3. Repo instructions ([`../../AGENTS.md`](../../AGENTS.md), `.cursor/rules`, `.agents/skills`) — these override generic FIRST
+4. [`../principles/X.md`](../principles/API.md) then `X.md` in this folder
+
+Do not install a FIRST skill. Use existing tech and workflow skills.
+
+## Discovery loop
+
+1. Name one primary station. Load a secondary spec only if the change crosses that station’s boundary.
+2. Read the generic spec, then this instance.
+3. Inspect implementation and `apps/docu`. Distinguish facts, inferences, assumptions, questions.
+4. Propose the smallest useful update: portable factory wording, this instance, or a durable project file.
+5. Implement against that contract.
+6. Validate with this repo’s checks (`pnpm qa`, OpenAPI drift, targeted tests). Run `python3 _first/scripts/validate_docs.py` only when generic FIRST files changed.
+7. Update this instance if a real path or check was learned. Update `../principles/X.md` only if the portable recipe was wrong.
+
+## Format sync
+
+When `../principles/` headings change, update every station file here in the same session. Do not teach this folder to `../scripts/validate_docs.py`.
+
+Required `##` headings (copy of `principleHeadings`):
+
+`Principle` · `Statement` · `Outcome` · `Artifacts` · `Minimum Useful Artifact` · `Recipe` · `Validation` · `Definition of Done` · `Agent Prompt` · `Notes`
+
+Filenames match the twelve stations in order: PRODUCT, JOURNEYS, DESIGN, ARCHITECTURE, DATA, API, DOCUMENTATION, WORKFLOW, PIPELINES, QUALITY, SECURITY, OPERATIONS.
+
+## Link convention
+
+From a station file in this folder:
+
+- Generic spec: `../principles/X.md`
+- Essay: `../articles/X.md`
+- Factory map: `../ABOUT.md`
+- Docs: `../../apps/docu/content/docs/…`
+- Repo root: `../../README.md`
+
+## Stations
+
+| # | Station | Instance |
+|---:|---|---|
+| 1 | Product | [PRODUCT.md](PRODUCT.md) |
+| 2 | Journeys | [JOURNEYS.md](JOURNEYS.md) |
+| 3 | Design | [DESIGN.md](DESIGN.md) |
+| 4 | Architecture | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| 5 | Data | [DATA.md](DATA.md) |
+| 6 | API | [API.md](API.md) |
+| 7 | Documentation | [DOCUMENTATION.md](DOCUMENTATION.md) |
+| 8 | Workflow | [WORKFLOW.md](WORKFLOW.md) |
+| 9 | Pipelines | [PIPELINES.md](PIPELINES.md) |
+| 10 | Quality | [QUALITY.md](QUALITY.md) |
+| 11 | Security | [SECURITY.md](SECURITY.md) |
+| 12 | Operations | [OPERATIONS.md](OPERATIONS.md) |
+
+Do not invent TAM, event taxonomies, or SLOs to complete a template. Label **Fact**, **Drift**, and **Unresolved** under Artifacts.

--- a/_first/basilic/SECURITY.md
+++ b/_first/basilic/SECURITY.md
@@ -1,0 +1,82 @@
+# Security First
+
+## Principle
+
+Identify what you are trusting, protecting, exposing, and allowing — proportionally to actual risk — before architecture makes security assumptions expensive to change.
+
+## Statement
+
+Security is not a phase at the end. It is a set of decisions about boundaries: who can access what, what data is sensitive, what inputs are untrusted, what an agent is allowed to touch. I scale rigor to risk — an internal tool and a regulated financial product do not get the same bar. I also do not pretend risk is zero.
+
+## Outcome
+
+Trust boundaries are documented. Auth rules are consistent and enforced at boundaries. Secrets are not committed and not logged. External inputs are validated. Agent permissions are scoped: read-only where possible, destructive actions gated, secrets minimized, human approval for high-risk operations.
+
+## Artifacts
+
+- **Fact:** [`../../apps/docu/content/docs/architecture/security.mdx`](../../apps/docu/content/docs/architecture/security.mdx) — scanners, CORS, rate limits
+- **Fact:** [`../../apps/docu/content/docs/architecture/authentication.mdx`](../../apps/docu/content/docs/architecture/authentication.mdx) — JWT, methods, keys
+- **Fact:** Pre-commit: block-files → gitleaks → OSV → Biome. Commands: `pnpm security:check`
+- **Fact:** CI: [`.github/workflows/security.yml`](../../.github/workflows/security.yml) (every PR + main); [`.github/workflows/deepsec.yml`](../../.github/workflows/deepsec.yml) (trusted same-repo PRs)
+- **Fact:** Principals: session JWT (`typ=access` / `typ=refresh`); machine API key `bask_<prefix>_<secret>` hashed at rest
+- **Fact:** Web gate: [`../../apps/web/proxy.ts`](../../apps/web/proxy.ts) only. Do not duplicate in layouts.
+- **Fact:** CORS SoT: Fastify `ALLOWED_ORIGINS` (`apps/api/src/plugins/cors.ts`). Prod fails on `*` or empty. Not `vercel.json`.
+- **Fact:** Login-route rate-limit subset as shipped in security MDX. In-memory per instance (Operations names the replica gap).
+- **Fact:** Cookie `api.session` is `httpOnly: false` by design so the browser client can read tokens. Same-origin `update-tokens` + Fastify `validate-tokens` before write.
+- **Fact:** Secrets: `ENCRYPTION_KEY`, `JWT_SECRET`, OAuth client secrets, `RESEND_API_KEY`, AI keys, `SENTRY_DSN`, `DATABASE_URL`, `AI_GATEWAY_API_KEY`, `EXPO_TOKEN`
+- **Unresolved:** named threat model; data classification list; in-product AI tool permission matrix
+- **Unresolved:** accepted-risk register with owner and next review
+
+Treat coding agents as a service account: least privilege, no secrets, human approval for destructive or trust-boundary edits.
+
+## Minimum Useful Artifact
+
+- protected: sessions, API keys, wallets, OAuth tokens, env secrets
+- principals: public, JWT user, API key
+- trust boundaries: Next proxy, Fastify auth plugins, TypeBox on untrusted input
+- agent: read-only inspection default; stop for secrets, destructive ops, auth policy changes
+- accepted risks: `httpOnly: false` cookie (documented); in-memory rate limit; **unresolved** as a dated register
+
+## Recipe
+
+1. Inspect security MDX, auth MDX, `apps/web/proxy.ts`, Fastify auth/CORS/security plugins, scanners.
+2. Understand what is stored, transmitted, logged, and exposed to agents (coding and `/ai/*`).
+3. Identify auth drift across web/API/CLI, secrets in logs, untrusted input without TypeBox.
+4. Propose the smallest security fix or documentation update.
+5. Scope agent permissions like a role. Gate destructive work.
+6. Implement with existing scanners and auth patterns. Do not invent a parallel auth system.
+7. Validate with `pnpm security:check` and existing auth tests. Failures fixed or explicitly accepted.
+8. Update security MDX when the trust model changes; update this instance.
+
+## Validation
+
+- Auth enforced at proxy and Fastify, not ad hoc per handler.
+- No secrets in code, logs, or agent-accessible files without justification.
+- Destructive and high-risk operations require human approval.
+- Security scans pass, or failures are accepted with rationale.
+
+## Definition of Done
+
+Trust boundaries and permissions are documented and implemented consistently. Agent access is scoped. Identified risks are addressed or explicitly accepted at the appropriate level.
+
+## Agent Prompt
+
+Apply Security First to Basilic.
+
+Read security and authentication MDX, `apps/web/proxy.ts`, Fastify auth, CORS, and scanners before changing trust boundaries. Inspect implementation; do not assume docs match.
+
+Prefer read-only inspection. Avoid secrets. Require a human for destructive or security-consequential changes. Treat yourself as a service account. Do not define TypeBox shapes here (API) or journey maps (Journeys).
+
+Propose the smallest useful security fix or documentation update. Use existing scanners. Update durable security artifacts when the trust model changes. Update this instance when paths change.
+
+## Notes
+
+**Security vs Operations:** Security defines trust, protection, and permissions. Operations defines runtime visibility and recovery.
+
+**Security vs API:** API defines contracts at boundaries. Security defines who may invoke them and what they may access.
+
+**Security vs Architecture:** Architecture maps trust boundaries. Security defines protection and authorization policy across them.
+
+**Security vs Data:** Data maps classification, copies, retention, and deletion. Security owns access and protection policy.
+
+**Navigation:** [Generic spec](../principles/SECURITY.md) · [Human essay](../articles/SECURITY.md) · [Factory map](../ABOUT.md) · [Security](../../apps/docu/content/docs/architecture/security.mdx) · [Authentication](../../apps/docu/content/docs/architecture/authentication.mdx)

--- a/_first/basilic/WORKFLOW.md
+++ b/_first/basilic/WORKFLOW.md
@@ -1,0 +1,72 @@
+# Workflow First
+
+## Principle
+
+Make the path from intent to validated change explicit enough that humans, agents, and automation can cooperate without reconstructing the process every time.
+
+## Statement
+
+I care less about which methodology name is on the wall and more about whether work can move from idea to shipped, validated change. Who decides what? Where does state live? When does a human approve? If the path is only in people's heads, agents cannot help and humans cannot scale.
+
+## Outcome
+
+Work flows through a recognizable path: idea → plan → implement → review → pipeline signals → approval → release → learning. Handoffs have inputs and outputs. Work state lives in issues, tasks, or PRs — not only in chat. Human approval is explicit for destructive, security-sensitive, or product-consequential changes.
+
+## Artifacts
+
+- **Fact:** Path: plan (`/plan-feature`) → review → implement (`/exec-push`) → `/git-commit` → PR → CI + CodeRabbit → `/retro`
+- **Fact:** Index: [ai-workflow.mdx](../../apps/docu/content/docs/development/ai-workflow.mdx)
+- **Fact:** Playbooks: `.agents/skills/workflow/` — `plan-feature`, `exec-push`, `git-commit`, `code-review`, `deslop`, `retro`, `git-create-pr`
+- **Fact:** Work state: GitHub issues and pull requests
+- **Fact:** Consequential decisions: ADRs and `apps/docu`
+- **Fact:** Git: default global user; Conventional Commits; never `--no-verify`; never Co-authored-by trailers ([git.mdc](../../.cursor/rules/base/git.mdc))
+- **Fact:** Human gates: product scope, secrets/trust boundaries, destructive ops ([`../AGENTS.md`](../AGENTS.md))
+- **Fact:** Models (docs): Grok 4.6 plan/implement; Sol long-horizon; Composer 2.5 mechanical. In-app chat is a product model, not this workflow.
+
+## Minimum Useful Artifact
+
+- intent, owner, visible state: issue or PR
+- plan and acceptance criteria: `/plan-feature` for non-trivial work
+- actors: human, agent, CI, CodeRabbit
+- gates: product, security, destructive — ask a human
+- validation: CI; learning: `/retro` and durable files when decisions changed
+
+## Recipe
+
+1. Inspect issues, PRs, branch, CI, and any plan.
+2. Understand the actor for this step.
+3. Identify missing plan, missing owner, approval only in chat.
+4. Propose before implementing on non-trivial work. Surface assumptions.
+5. Implement in small, reviewable chunks. Keep state in the issue or PR.
+6. Hand off to review with enough context (`/code-review`).
+7. Run validation through existing pipelines. Fix or escalate.
+8. Obtain approval for consequential changes. Release. Capture learning in files.
+
+## Validation
+
+- Work state is visible without asking in chat.
+- Handoffs include enough context for the next actor.
+- Consequential decisions are in `apps/docu` or ADRs, not only merged code.
+- Failed validation routes to a clear owner and next action.
+
+## Definition of Done
+
+The change moved through an explicit path. State is updated. Durable context reflects what was decided. The next actor can continue without reconstruction.
+
+## Agent Prompt
+
+Apply Workflow First to Basilic.
+
+Read current issues/PRs, ai-workflow MDX, and `.agents/skills/workflow/` before acting. Do not rely on chat as the system of record.
+
+Propose before implementing on non-trivial work. Implement in reviewable chunks. Use `/exec-push` and `/git-commit`. Never `--no-verify`. Use the default global git user.
+
+Stop and ask a human for product scope, security-sensitive changes, and destructive operations. Update issues, PRs, and documentation as work progresses. Preserve intentional existing process.
+
+## Notes
+
+**Workflow vs Pipelines:** Workflow is how actors respond. Pipelines are the automated format, test, build, and deploy mechanics.
+
+**Workflow vs Documentation:** Workflow determines when context is created. Documentation preserves it.
+
+**Navigation:** [Generic spec](../principles/WORKFLOW.md) · [Human essay](../articles/WORKFLOW.md) · [Factory map](../ABOUT.md) · [AI workflow](../../apps/docu/content/docs/development/ai-workflow.mdx)

--- a/_first/principles/API.md
+++ b/_first/principles/API.md
@@ -1,0 +1,85 @@
+# API First
+
+## Principle
+
+Define the capability and its boundary before consumers couple to an accidental implementation.
+
+## Statement
+
+I treat the capability and its boundary as a design decision, not an implementation leftover. Before a second consumer depends on a shape, I want to know what goes in, what comes out, what fails, which Security-owned authorization requirement applies, and how denial appears. That contract might be HTTP, a typed module, an event, a CLI, or an agent tool. The format matters less than making the boundary explicit on purpose.
+
+## Outcome
+
+Meaningful boundaries have explicit inputs, outputs, errors, and references to applicable authorization requirements. Implementations enforce those requirements and conform, or the contract is updated deliberately. Agent tools have the same explicitness as HTTP routes. A second consumer can be written without reading the handler.
+
+## Artifacts
+
+- OpenAPI, GraphQL, protobuf, or equivalent schema
+- Typed contracts in code (TypeBox, Zod, and similar)
+- Error models plus Security-owned authorization requirements represented and enforced at the boundary
+- Event definitions and integration specs
+- Agent tool and MCP schemas
+- Module or package interfaces that other packages actually import
+- Generated clients or types, when the toolchain supports them
+- Contract tests that fail when spec and implementation disagree
+
+Do not force Markdown where a schema is the source of truth.
+
+## Minimum Useful Artifact
+
+- capability or operation name and purpose
+- inputs, outputs, and stable identifiers
+- error and denial behavior
+- reference to the Security-owned authorization requirement
+- idempotency and versioning decision when relevant
+- one contract check that detects implementation drift
+
+## Recipe
+
+1. Inspect existing routes, schemas, clients, events, and tool definitions.
+2. Understand which capabilities the product actually offers, and which consumers already depend on them.
+3. Identify gaps: undocumented boundaries, spec/implementation drift, inconsistent errors or authorization enforcement, tools with no schema.
+4. Propose the smallest useful contract change. Keep intentional existing decisions.
+5. Make inputs, outputs, errors, applicable authorization requirements, and denial behavior explicit. Add idempotency and versioning only where they already matter.
+6. Implement against the contract. Do not let the handler invent a parallel shape.
+7. Validate with schema checks, contract tests, and the project's existing API tests.
+8. Update the durable contract and generated artifacts when behavior changes.
+
+## Validation
+
+- A second consumer can be written against the contract without reading the handler.
+- Request and response shapes match the documented contract, or the discrepancy is named.
+- Errors follow one model, not a dialect per endpoint.
+- Security-owned authorization policy is referenced and enforced at the boundary, not redefined or scattered as comments in handlers.
+- Agent tools have name, inputs, outputs, and failure behavior.
+- Breaking changes are visible before merge.
+
+## Definition of Done
+
+Contracts are documented and implementations conform, or discrepancies are named. Breaking changes are identified before merge.
+
+## Agent Prompt
+
+Apply API First to this repository.
+
+Read existing API documentation, schema files, typed contracts, error models, Security-owned authorization rules, agent tool definitions, and the implementation that claims to follow them. Inspect handlers, clients, and tests. Do not assume the spec is correct.
+
+Identify the capabilities the product actually offers and the boundaries those capabilities cross: HTTP, events, modules, CLIs, or agent tools. Separate what is explicit in a contract from what is implied by code.
+
+Find drift and missing decisions: inputs, outputs, errors, authorization references and enforcement, idempotency, versioning. Preserve intentional existing API decisions. Do not define a new authorization policy here or widen scope into a public platform unless the product already is one.
+
+Propose the smallest useful boundary: one operation, one event, or one tool made explicit. Implement against the contract. Validate with the project's existing schema and API checks. When behavior or a contract decision changes, update the durable API artifacts in the same work.
+
+## Notes
+
+**API vs Product:** Product names the capability and why it exists. API names how systems ask for it.
+
+**API vs Architecture:** Architecture decides which parts communicate. API defines the contract across that boundary.
+
+**API vs Data:** Data owns canonical domain meaning. API owns the consumer-facing representation and compatibility promise.
+
+**API vs Security:** Security owns who may invoke a capability and what they may access. API owns how that requirement, credentials, and denial behavior appear and are enforced at the contract boundary.
+
+**API vs Documentation:** The schema is the contract. Documentation explains why it looks that way.
+
+**Navigation:** [Human essay](../articles/API.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/ARCHITECTURE.md
+++ b/_first/principles/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# Architecture First
+
+## Principle
+
+Decide system boundaries, dependency direction, and deployment shape before local implementation choices harden into structural constraints.
+
+## Statement
+
+I treat architecture as the small set of decisions that are expensive to reverse: where responsibilities live, which dependencies point where, what crosses a process or trust boundary, and how the system is deployed. I do not design every class in advance. I make the consequential structure visible before the codebase makes it accidentally.
+
+## Outcome
+
+The system has an inspectable structural model at the level its scale requires. Components have named responsibilities and owners. Dependency direction, external systems, data stores, and deployment units are visible. Consequential choices have rationale and known tradeoffs. Implementation conforms, or the model is updated deliberately.
+
+## Artifacts
+
+- System context and container or component diagrams where they add value
+- Architecture decision records for choices that are expensive to reverse
+- Module boundaries and dependency rules enforced in code where practical
+- Deployment topology and external dependency inventory
+- Build-versus-buy decisions and structural constraints
+- Ownership notes for major components and integrations
+
+Do not diagram code an IDE can reveal. Show boundaries, relationships, and decisions a reader would otherwise have to reconstruct.
+
+## Minimum Useful Artifact
+
+For a small system, one page is enough:
+
+- purpose and scope
+- users and external systems
+- deployable units and data stores
+- labeled dependencies and their direction
+- two or three consequential decisions, constraints, or unknowns
+
+## Recipe
+
+1. Inspect the repository layout, runtime entry points, deployment configuration, data stores, and external integrations.
+2. Understand the product capabilities and quality attributes that constrain the structure.
+3. Identify the boundaries already present in code and deployment, including accidental coupling and shared state.
+4. Propose the smallest structural clarification or change. Prefer one boundary or decision over a complete redesign.
+5. Record the rationale, alternatives, consequences, and trigger for reconsideration when the choice is consequential.
+6. Implement with dependency direction visible and enforceable where the project supports it.
+7. Validate the model against the running and deployed system, not only the directory tree.
+8. Update diagrams and decision records when structure or deployment shape changes.
+
+## Validation
+
+- A new contributor can name the major parts, their responsibilities, and how they depend on one another.
+- Diagrams match code and deployment, or discrepancies are named.
+- New dependencies follow the intended direction.
+- Consequential choices have rationale and tradeoffs, not only a technology name.
+- The architecture is proportional to the product and its risks.
+
+## Definition of Done
+
+The structural decision is explicit, implemented, and validated. Boundaries and dependency direction are inspectable. Durable architecture artifacts match the system or record deliberate drift.
+
+## Agent Prompt
+
+Apply Architecture First to this repository.
+
+Read product constraints, existing architecture notes and ADRs, repository structure, deployment configuration, data stores, and external integrations. Inspect the implementation and running topology; do not assume diagrams are current.
+
+Identify the decisions that are expensive to reverse: system boundaries, dependency direction, shared state, deployment units, and external dependencies. Preserve intentional existing structure. Do not introduce services, layers, queues, or platforms merely because they are common elsewhere.
+
+Propose the smallest useful structural change or artifact. Record rationale and tradeoffs for consequential choices. Validate the model against code and deployment. Update durable architecture artifacts when structure changes.
+
+## Notes
+
+**Architecture vs Product:** Product names the capability and constraints. Architecture assigns responsibilities and structural boundaries.
+
+**Architecture vs Data:** Architecture places stores and data flows. Data owns canonical meaning, ownership, lifecycle, and evolution.
+
+**Architecture vs API:** Architecture decides which components communicate. API defines the contract across a boundary.
+
+**Architecture vs Pipelines:** Architecture describes deployment units and topology. Pipelines build, validate, and deliver them.
+
+**Architecture vs Operations:** Architecture names the running parts. Operations observes and recovers them.
+
+**Navigation:** [Human essay](../articles/ARCHITECTURE.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/DATA.md
+++ b/_first/principles/DATA.md
@@ -1,0 +1,86 @@
+# Data First
+
+## Principle
+
+Define canonical domain concepts, ownership, lifecycle, and change rules before stores, schemas, and events proliferate competing truths.
+
+## Statement
+
+I treat data as durable product state with meaning, ownership, and a lifecycle—not as columns left behind by features. Before several stores or consumers encode the same concept differently, I want to know what the concept means, which system is authoritative, how identity works, how it changes, how long it lives, and how it is removed.
+
+## Outcome
+
+Core domain concepts have shared names and definitions. Each important dataset has an owner and authoritative source. Identity, constraints, retention, deletion, lineage, and schema evolution are explicit at the level the product needs. Migrations preserve or deliberately transform meaning. Copies do not silently become competing sources of truth.
+
+## Artifacts
+
+- Domain glossary or lightweight conceptual model
+- Source-of-truth and ownership map for important datasets
+- Logical schemas and integrity constraints
+- Identity and deduplication rules
+- Retention, deletion, residency, and archival rules
+- Migration and schema-evolution plans
+- Lineage notes for derived or replicated data
+- Data quality rules tied to domain invariants
+
+Use executable schemas and constraints as sources of truth when they can express the rule. Markdown explains meaning, ownership, and decisions the schema cannot.
+
+## Minimum Useful Artifact
+
+For one domain concept, record:
+
+- name and plain-language definition
+- stable identity and key invariants
+- authoritative owner and source
+- writers, readers, and derived copies
+- retention/deletion rule
+- current schema version or migration risk
+
+## Recipe
+
+1. Inspect schemas, migrations, models, events, analytics tables, caches, and external data sources.
+2. Understand the core domain concepts and where each is created, changed, copied, and deleted.
+3. Identify gaps: competing definitions, unclear ownership, weak identity, unenforced invariants, stale copies, or unsafe migrations.
+4. Propose the smallest useful clarification—one concept, owner, constraint, lineage path, or migration rule.
+5. Define canonical meaning and authority before choosing a new store or representation.
+6. Implement constraints and migrations with rollback, compatibility, and backfill needs made explicit.
+7. Validate existing data, read/write paths, derived copies, and deletion behavior.
+8. Update durable data artifacts when meaning, ownership, lifecycle, or schema changes.
+
+## Validation
+
+- A contributor can identify the authoritative source and owner for each critical dataset.
+- Core concepts have one canonical meaning even when several representations exist.
+- Domain invariants are enforced in the strongest practical layer.
+- Schema changes include compatibility, migration, and rollback or recovery reasoning.
+- Retention and deletion behavior match Security and product requirements.
+
+## Definition of Done
+
+The affected domain concepts, ownership, invariants, lifecycle, and evolution rules are explicit. Implementations and migrations preserve them, or deliberate transformations and unresolved risks are documented.
+
+## Agent Prompt
+
+Apply Data First to this repository.
+
+Read domain documentation, schemas, migrations, models, events, analytics definitions, retention rules, and the implementation that reads and writes them. Trace important data from creation through copies and deletion. Do not assume the database schema expresses the whole domain model.
+
+Identify competing truths, unclear ownership, unstable identity, missing constraints, unsafe evolution, and stale derived data. Preserve intentional existing models. Do not introduce a data platform, warehouse, event bus, or new source of truth unless the product already needs one.
+
+Propose the smallest useful data decision. Implement constraints and migrations using existing project patterns. Validate real read/write paths and existing data where safe. Update durable artifacts when meaning, ownership, lifecycle, or schema changes.
+
+## Notes
+
+**Data vs Product:** Product owns event taxonomy and the outcomes to measure. Data owns the meaning, authority, and lifecycle of the resulting records.
+
+**Data vs Architecture:** Architecture places stores and data flows. Data defines what the state means and which source is authoritative.
+
+**Data vs API:** Data owns the canonical domain model. API owns the external representation and compatibility contract.
+
+**Data vs Security:** Data records classification, retention, and deletion requirements. Security owns access policy and protection.
+
+**Data vs Quality:** Data owns domain invariants and dataset integrity. Quality owns release gates and eval datasets.
+
+**Data vs Operations:** Data owns product state and lineage. Operations owns telemetry about system health.
+
+**Navigation:** [Human essay](../articles/DATA.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/DESIGN.md
+++ b/_first/principles/DESIGN.md
@@ -1,0 +1,76 @@
+# Design First
+
+## Principle
+
+Decide how the product behaves and communicates through its interface before layout and components become accidental consequences of implementation.
+
+## Statement
+
+Useful software is the floor. The product people remember is the one that feels clear, thoughtful, and enjoyable to use. I treat design as behavior, hierarchy, states, copy, and motion — not decoration bolted on at the end. Before I add a pattern, I look at what the project already has and reuse it. Invention is for when the problem actually needs it.
+
+## Outcome
+
+The interface follows a coherent design system: tokens, primitives, composition rules, and content patterns. Loading, empty, error, success, and disabled states are defined. New UI reuses established patterns. The agent-readable identity and the implementation agree, or the discrepancy is named. Browser verification across states is the bar.
+
+## Artifacts
+
+- `DESIGN.md` when the project wants an agent-readable identity (YAML tokens plus rationale)
+- Design system in code: CSS variables, Tailwind `@theme`, component library
+- UI conventions and component definitions
+- Interaction specifications and interface state definitions
+- Accessibility requirements beyond token contrast
+- Content and copy patterns
+- Motion guidelines (duration, easing, when to animate)
+
+If `DESIGN.md` exists: YAML tokens are the values to use; markdown do's and don'ts are constraints. Token shape may follow W3C Design Tokens (DTCG). Export to Tailwind `@theme` or `tokens.json` if the project already does. Use the project's pinned lint command, or `npx @google/design.md lint DESIGN.md` when the CLI is already part of the toolchain. It reports broken token references and contrast warnings on component color pairs. A zero exit code is not an accessibility pass or browser verification.
+
+Do not keep a palette in `DESIGN.md` and a different one in CSS.
+
+## Minimum Useful Artifact
+
+- user goal and required interface states
+- existing tokens, primitives, and patterns to reuse
+- interaction and content behavior for each state
+- keyboard, contrast, focus, and reduced-motion constraints
+- browser views or notes showing how the states were verified
+
+## Recipe
+
+1. Inspect `DESIGN.md` if present, tokens in code, the component library, and adjacent screens.
+2. Understand the states the feature needs: default, loading, empty, error, success, disabled.
+3. Identify gaps: missing states, values outside the system, DESIGN.md/code drift.
+4. Propose primitives from the existing system. New components only when nothing fits.
+5. Define interaction: click, submit, dismiss, navigate back. Add motion only where it improves feedback.
+6. Implement with existing primitives. Do not introduce hex values or typefaces outside the system.
+7. Validate in the browser across states, keyboard, and reduced motion. Lint DESIGN.md if the project has the CLI.
+8. Update design artifacts if you introduced a pattern worth reusing.
+
+## Validation
+
+- New UI uses existing tokens and components unless a gap is documented.
+- `DESIGN.md` and the implementation agree, or the discrepancy is named.
+- All required states render and behave correctly.
+- Motion respects `prefers-reduced-motion`.
+- A green DESIGN.md lint is not browser verification.
+
+## Definition of Done
+
+Interface behavior matches design intent. States are handled. Patterns are reusable or documented. Tokens in the agent-readable file and in code are the same system.
+
+## Agent Prompt
+
+Apply Design First to this repository.
+
+Read `DESIGN.md` if it exists, then design system documentation, UI conventions, journey flows, and existing components before building new interface. Inspect how similar features are implemented. Treat YAML tokens as the values to use and markdown do's and don'ts as constraints.
+
+Reuse established primitives. Do not invent new components, hex values, or typefaces without checking the design system first. If tokens live in CSS or Tailwind and `DESIGN.md` disagrees or is absent, do not silently create a second palette.
+
+Define loading, empty, error, and success states. Use motion for feedback, not decoration. Respect reduced motion. Validate in the browser across states. A screenshot of the default view is not verification. Update durable design artifacts when patterns change.
+
+## Notes
+
+**Design vs Journeys:** Journeys define what happens. Design defines how the interface expresses it.
+
+**Design vs API:** API is the capability boundary. Design is the human-visible expression. `DESIGN.md` is an artifact, not the principle — parallel to OpenAPI versus API First.
+
+**Navigation:** [Human essay](../articles/DESIGN.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/DOCUMENTATION.md
+++ b/_first/principles/DOCUMENTATION.md
@@ -1,0 +1,73 @@
+# Documentation First
+
+## Principle
+
+Keep the context future humans and agents need to decide well in durable project files, not in conversations that disappear.
+
+## Statement
+
+I document decisions and context, not obvious code. If someone will need to rediscover it, explain it twice, or guess why we chose this, it belongs in a file. Chat is for coordination. Files are the system of record. Wrong docs are worse than no docs.
+
+## Outcome
+
+Consequential decisions, conventions, setup steps, and domain context live in discoverable project files. Documentation matches current behavior or explicitly notes drift. When behavior or assumptions change, the files change in the same work.
+
+## Artifacts
+
+- `README.md` and package READMEs
+- `AGENTS.md` and agent instructions
+- Architecture documentation and ADRs
+- Project conventions and operational notes
+- Domain documentation and setup guides
+- Changelog entries for behavior changes worth remembering
+- `llms.txt` for selective public-site orientation when the product publishes substantial web documentation
+
+Prefer linking over duplicating. One canonical source, pointers elsewhere.
+
+Public documentation may include `llms.txt` as a selective, machine-readable orientation to website content. It complements human navigation and `sitemap.xml`; it does not replace repository agent instructions in `AGENTS.md`. Mention it in `AGENTS.md` only when agents are responsible for regenerating or validating it as public documentation changes.
+
+## Minimum Useful Artifact
+
+- intended reader and the question the document answers
+- canonical location and links from likely entry points
+- decision, constraint, or procedure that cannot be inferred safely
+- relevant implementation or source-of-truth links
+- owner or event that should trigger the next review
+
+## Recipe
+
+1. Inspect what documentation exists and where humans and agents look first.
+2. Understand how those files compare to implementation. Flag contradictions and drift.
+3. Identify missing context: decisions, constraints, conventions, setup, domain rules.
+4. Propose the smallest useful doc — decision record, convention note, README section.
+5. Write it. Prefer one canonical source.
+6. When implementing, update docs in the same change if behavior or assumptions changed.
+7. Remove or archive docs that are wrong or obsolete.
+8. Validate that a new contributor can set up and orient from files without asking in chat.
+
+## Validation
+
+- A new contributor can set up and orient from docs without asking in chat.
+- ADRs exist for consequential architectural decisions, or the decision is explicitly deferred.
+- Agent instructions reflect how the project actually works today.
+- Chat is not treated as the system of record.
+
+## Definition of Done
+
+Durable context is written, accurate, and discoverable. Documentation drift is resolved or explicitly tracked. Future work will not need to rediscover what was already decided.
+
+## Agent Prompt
+
+Apply Documentation First to this repository.
+
+Read existing READMEs, AGENTS.md, architecture docs, ADRs, and the target project's own instructions before acting. Compare documentation to implementation. Identify contradictions, drift, and missing context.
+
+Document decisions and conventions — not obvious code. Preserve intentional existing documentation. Propose the smallest useful doc update. When you change behavior, constraints, or conventions, update the durable project files in the same work. Do not add documentation volume without a clear future reader. Do not leave load-bearing decisions only in chat.
+
+## Notes
+
+**Documentation vs everything:** Other stations produce decisions. Documentation decides which context must stay durable.
+
+**Documentation vs Workflow:** Workflow determines when context is created and handed off. Documentation preserves it.
+
+**Navigation:** [Human essay](../articles/DOCUMENTATION.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/JOURNEYS.md
+++ b/_first/principles/JOURNEYS.md
@@ -1,0 +1,72 @@
+# Journeys First
+
+## Principle
+
+Map how someone finishes a job — including errors, permissions, and state — before implementation invents the path from whichever screen shipped first.
+
+## Statement
+
+The product is not a collection of screens. It is someone trying to finish a job. I map that job from entry to completion before I trust implementation to fill in the gaps. Happy paths are cheap. The product breaks in the alternates: the error nobody designed, the permission that exists on one route but not another, the state with no exit.
+
+## Outcome
+
+Actors, entry points, happy paths, alternates, error paths, permission gates, and completion criteria are documented or explicitly marked unknown. Missing states are visible before code hardens around an incomplete model.
+
+## Artifacts
+
+- Journey documents or flow descriptions
+- State diagrams for multi-step flows
+- Actor definitions (human, admin, agent, system)
+- Acceptance criteria tied to completion
+- Permission and error matrices for critical flows
+
+## Minimum Useful Artifact
+
+- actor, job, entry point, and preconditions
+- happy path from entry to completion
+- important alternate, error, cancel, and recovery paths
+- permission gates that reference Security-owned policy
+- completion criteria and explicit deferrals
+
+## Recipe
+
+1. Inspect product goals, existing routes, screens, API flows, and auth rules.
+2. Understand the actor and the job they are trying to finish — not the screen, the outcome.
+3. Identify gaps: missing error exits, permission drift across entry points, states with no resume.
+4. Propose the smallest useful map: one job, its entries, its gates, its completion.
+5. Write happy path, then alternates, then errors, then permission gates.
+6. Compare the map to implementation. Flag missing or contradictory states.
+7. Validate that a reviewer can trace every mapped state to implemented behavior or an explicit deferral.
+8. Update journey artifacts when flow behavior changes.
+
+## Validation
+
+- Every critical flow has defined error and recovery behavior.
+- Permission checks are consistent across entry points.
+- Every mapped state traces to implemented behavior or an explicit deferral; accidental gaps fail validation.
+
+## Definition of Done
+
+Critical flows are mapped with happy, alternate, and error paths documented or explicitly deferred. Implementation matches the map, or the map was updated to reflect a deliberate change.
+
+## Agent Prompt
+
+Apply Journeys First to this repository.
+
+Read product documentation, journey artifacts if they exist, and the current implementation of user-facing flows. Map actors, entry points, states, permissions, errors, and completion criteria. Compare documentation to actual behavior.
+
+Do not invent UI. Describe what happens and why. Surface missing states and edge cases before implementing. Preserve intentional existing flow decisions. Propose the smallest useful update to journey artifacts. Update durable project files when flow behavior changes.
+
+Treat agents in the product as actors in the flow. If an actor is unnamed, do not invent a tool for them.
+
+## Notes
+
+**Journeys vs Product:** Product answers what and why. Journeys answer how someone finishes.
+
+**Journeys vs Design:** Journeys describe behavior and flow. Design describes how that behavior is expressed through the interface.
+
+**Journeys vs Security:** Journeys show where a permission gate occurs and what the actor experiences. Security owns the permission policy.
+
+**Journeys vs Data:** Journeys describe actor-visible states and transitions. Data owns the canonical meaning and lifecycle of persisted state.
+
+**Navigation:** [Human essay](../articles/JOURNEYS.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/OPERATIONS.md
+++ b/_first/principles/OPERATIONS.md
@@ -1,0 +1,78 @@
+# Operations First
+
+## Principle
+
+Decide how you will see, support, and recover the running system before production becomes a black box.
+
+## Statement
+
+Shipping is not the end of engineering work. It is when the system meets reality. I want to know what it is doing, what failed, for whom, and how to fix it — without archaeology. A product nobody can operate is a product that will fail quietly.
+
+## Outcome
+
+Production behavior is observable at the level the project needs. Logs are structured and useful. Metrics and alerts cover critical failure modes. Runbooks exist for known recovery paths. Product analytics are not the same dashboard as engineering health. A green pipeline after a fix is not verified recovery.
+
+## Artifacts
+
+- Observability configuration (logging, metrics, tracing)
+- Dashboards and alert rules for system health
+- Runbooks and recovery procedures
+- Operational documentation (deploy behavior, known failure modes)
+- Incident notes promoted to durable docs when patterns repeat
+- Identity, logs, and retries for production agents when the product has them
+
+Keep this proportional. A brochure site does not need a tracing mesh.
+
+## Minimum Useful Artifact
+
+- critical runtime path and the failure that would strand a user
+- structured signal and join key used to diagnose it
+- alert condition, owner, and escalation path
+- tested recovery steps
+- running-system evidence that recovery succeeded
+
+## Recipe
+
+1. Inspect how the system reports health: logs, metrics, traces, user-facing errors.
+2. Understand critical failure modes: what breaks, how it surfaces, who notices first.
+3. Identify gaps: a 500 with no request id, a queue that dies silently, a deploy that cannot be verified.
+4. Propose the smallest useful signal — one log field, one metric, one alert.
+5. Write or update a runbook for recovery paths that have burned time.
+6. Implement. Do not invent product events here — that is Product First.
+7. When production reveals a bug, route through workflow: issue → fix → pipeline → verify recovery in the running system.
+8. Update operational docs when behavior, deploy process, or failure modes change.
+
+## Validation
+
+- A developer can diagnose a common failure from logs or metrics without guessing.
+- Alerts fire on real problems, not noise.
+- Recovery steps are documented and were tested or exercised.
+- Post-fix deploy was verified in production or staging. CI green is not that verification.
+
+## Definition of Done
+
+Runtime behavior is observable enough to support and debug. Recovery paths are known. Production feedback can enter the development workflow and close the loop.
+
+## Agent Prompt
+
+Apply Operations First to this repository.
+
+Read operational documentation, logging configuration, metrics, alerts, and runbooks before changing runtime behavior. Inspect how the system reports errors and health. Identify blind spots in observability.
+
+Propose the smallest useful logging, metric, or alert improvement. When diagnosing production issues, use structured signals — not guesswork. Route fixes through the project's workflow and pipelines. Verify recovery after deploy in the running system.
+
+Product analytics — events, funnels, activation — belong with Product First. Do not file a missing success event as an ops ticket. Do not add observability complexity beyond project scale. Production agents need identity, logs, retries, and a trace of what they did.
+
+## Notes
+
+**Operations vs Pipelines:** Pipelines move changes into production. Operations understands and runs the system after deployment.
+
+**Operations vs Security:** Security defines trust and protection. Operations defines visibility and recovery.
+
+**Operations vs Product:** Product owns whether the bet is working. Operations owns whether the system is healthy. Same warehouse is fine. Same dashboard is not.
+
+**Operations vs Architecture:** Architecture names deployment units and topology. Operations observes, supports, and recovers them.
+
+**Operations vs Data:** Data owns product-state meaning and lineage. Operations owns telemetry about runtime health.
+
+**Navigation:** [Human essay](../articles/OPERATIONS.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/PIPELINES.md
+++ b/_first/principles/PIPELINES.md
@@ -1,0 +1,77 @@
+# Pipelines First
+
+## Principle
+
+Treat automated validation and delivery as part of the development feedback loop — including the agent feedback loop — not as a ritual after the real work.
+
+## Statement
+
+A change is not done when it compiles on my machine. It is done when it passes the same checks everyone else relies on, and when it can reach the environment it needs to reach. For agents, CI is ground truth: implement, run checks, read failures, fix or escalate, run again. I keep the path from source to deployable explicit at the level the project actually needs.
+
+## Outcome
+
+Changes flow through an automated path: format → lint → typecheck → test → build → preview (if applicable) → deploy → verify. The commit stage builds the artifact once. Later stages promote that artifact; they do not rebuild a different one per environment. Agents can interpret CI failure output and act.
+
+## Artifacts
+
+- CI workflow definitions
+- Deployment workflows and build configuration
+- Preview environment setup when the project has it
+- Release checks and deployment documentation
+- Local scripts that mirror CI where useful
+- The commit-stage artifact (the thing that gets promoted)
+
+Keep infrastructure proportional. A static site does not need an orchestration platform.
+
+## Minimum Useful Artifact
+
+- triggers and ordered validation stages
+- exact local commands that mirror automated checks
+- commit-stage artifact identity and storage
+- promotion path across environments without rebuilding
+- readable failure ownership and post-deploy verification step
+
+## Recipe
+
+1. Inspect the current pipeline: what runs, when, on what triggers.
+2. Understand the path from change to deployable artifact. Find where the binary or bundle is built.
+3. Identify gaps: missing checks, manual steps that should be automated, rebuild-per-environment, unreadable logs, flaky jobs.
+4. Propose the smallest pipeline improvement — one check, one workflow, one script.
+5. Implement. Keep proportional to project size. Build once; promote that artifact.
+6. Verify locally with the same commands CI uses when possible.
+7. Read CI output. Fix failures or escalate infrastructure limits. Unreadable logs are a pipeline bug.
+8. Document deploy and release steps if they are not already durable.
+
+## Validation
+
+- CI passes on the change branch.
+- Local validation commands match CI behavior.
+- The commit-stage artifact is what later stages deploy.
+- A green agent sandbox is not a substitute for the project's pipeline.
+- Deploy path is documented and was exercised or dry-run where safe.
+
+## Definition of Done
+
+The change is validated by automated pipelines and is deployable through the project's defined path. Pipeline config is updated if new checks were added.
+
+## Agent Prompt
+
+Apply Pipelines First to this repository.
+
+Read CI workflows, build configuration, and deployment documentation before changing delivery mechanics. Inspect what validation runs on each change. Use the project's existing lint, test, and build commands — mirror CI locally when possible.
+
+When implementation completes, ensure CI would pass. Read failure logs and fix or escalate. Do not treat a green local sandbox as the pipeline. Do not add pipeline complexity beyond what the project needs. Do not rebuild a different artifact per environment if the project already builds once.
+
+Distinguish pipeline failures from quality criteria failures — fix the code or the gate, not both at once without intent. Update deployment docs when delivery behavior changes.
+
+## Notes
+
+**Pipelines vs Workflow:** Pipelines automate validation and delivery. Workflow defines how humans and agents respond to those signals.
+
+**Pipelines vs Architecture:** Architecture defines deployment units and topology. Pipelines build and promote those units.
+
+**Pipelines vs Quality:** Quality names the bar. Pipelines run it.
+
+**Pipelines vs Operations:** Pipelines get changes into production. Operations runs what arrived.
+
+**Navigation:** [Human essay](../articles/PIPELINES.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/PRODUCT.md
+++ b/_first/principles/PRODUCT.md
@@ -1,0 +1,90 @@
+# Product First
+
+## Principle
+
+Define what you are building, for whom, why it is worth building, and how you will know — before implementation becomes the specification.
+
+## Statement
+
+I do not let the codebase become the product brief. Before I change meaningful behavior, I want a file that names the problem, who has it, why it is worth building, what we are not building, how it reaches people, and how we will know. Implementation can reveal a better option. It should not invent the goal.
+
+## Outcome
+
+The project has an inspectable answer to what, why, and how we will know. Non-goals, GTM, success metrics, and the tracking plan are written or explicitly unresolved. Named metrics have events, or are marked unmeasured. When the product is a business, market size and unit economics are stated as measured or as hypotheses.
+
+## Artifacts
+
+- `PRODUCT.md`, product brief, or lightweight PRD
+- Business goals and user goals, distinguished
+- Non-goals, requirements, and constraints
+- Go-to-market notes: audience, channel, first successful use
+- Success metrics: definition, target, timeframe
+- Tracking plan: events, properties, identity, funnels tied to those metrics
+- Validation board: hypothesis, metric, evidence, keep / iterate / kill
+- Assumptions and open questions
+- Issue or task links for unresolved product decisions
+
+When the product is a business, also:
+
+- Market size: TAM, SAM, SOM — with method and what is still a guess
+- Money model: pricing, LTV, CAC, payback, contribution margin; or an explicit non-revenue goal
+- Runway / burn / time to breakeven when the product is the company
+- AARRR as a prompt for acquisition through revenue, not a mandatory scorecard
+
+Do not invent TAM, LTV, or a fog of events to complete a template. An internal tool may have none of the finance fields. Then say so.
+
+## Minimum Useful Artifact
+
+- problem, users, and business or organizational goal
+- requirements, constraints, and explicit non-goals
+- audience, channel, and first successful use
+- one to three metrics with definition, target, and timeframe
+- events that make each metric observable, or `unmeasured`
+- assumptions, open questions, and named decision owners
+
+## Recipe
+
+1. Inspect existing product docs, issues, README, the running product, and claimed metrics.
+2. Understand what is shipped versus what is claimed, including GTM and measurement.
+3. Identify gaps: missing users, missing goal, success that cannot fail, named metrics with no events, hypotheses with no status.
+4. Propose the smallest useful update to the product artifact.
+5. Make decisions explicit, or name them as unresolved. Do not hide them in code.
+6. Implement the behavior and the events in the same change when the change can move a metric.
+7. After use, compare the metric to the target and record keep / iterate / kill.
+8. Update the artifact if behavior, assumptions, GTM, analytics, or the bet changed.
+
+## Validation
+
+- A new contributor can answer what we are building, who it is for, why it is worth it, and how we will know from files alone.
+- Success metrics can fail. They are not CI going green.
+- Named metrics have events in the product, or are explicitly marked unmeasured.
+- Go-to-market is named at the level the product needs.
+- No silent product decisions in code without a corresponding note or open question.
+
+## Definition of Done
+
+Product intent is documented or explicitly deferred with named owners. Implementation aligns with stated goals and non-goals, or the docs were updated. Success that was claimed is either instrumented or marked unmeasured.
+
+## Agent Prompt
+
+Apply Product First to this repository.
+
+Read existing product documentation, issues, implementation, success metrics, tracking plan, and analytics before proposing features. Do not assume documentation is correct. Compare it to what the code and UI actually do, and to what is actually measured.
+
+Preserve intentional existing product choices. Do not silently decide scope, priorities, business goals, market size, pricing, unit economics, success metrics, event names, or go-to-market. If TAM or LTV is missing and the product is not a business, say so rather than filling the blank.
+
+Separate release-gating acceptance criteria from post-launch success metrics. If a metric is named but not instrumented, that is a product gap — implement the event or mark it unmeasured. Do not file it as operations work.
+
+Propose the smallest useful update to product artifacts, including the tracking plan and validation board when hypotheses exist. When you change behavior that can move a metric, ship the analytics in the same work. If the bet changes, update durable project files.
+
+## Notes
+
+**Product vs Journeys:** Product names what, why, and how we will know. Journeys name how someone finishes.
+
+**Product vs Quality:** Product names the outcome after use. Quality names the bar that gates a release.
+
+**Product vs Operations:** Product owns events, funnels, activation. Operations owns logs, traces, error rates, alerts, recovery.
+
+**Product vs Data:** Product names events and outcomes to measure. Data owns canonical domain meaning, authority, lifecycle, and evolution.
+
+**Navigation:** [Human essay](../articles/PRODUCT.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/QUALITY.md
+++ b/_first/principles/QUALITY.md
@@ -1,0 +1,75 @@
+# Quality First
+
+## Principle
+
+Name what good means — acceptance, tests, evals, performance — before anyone optimizes toward an undefined target.
+
+## Statement
+
+I do not ask anyone to "make it better" without saying what better means. Tests prove deterministic behavior. Evals cover probabilistic output. Performance budgets beat vibes. Name the bar before you optimize, or you ship something that looks done and still fails users.
+
+## Outcome
+
+Acceptance criteria exist for features that matter. Tests protect critical paths. AI features with probabilistic output have evals where appropriate. Performance-sensitive areas have budgets. Humans and agents know what done means beyond "it compiles."
+
+## Artifacts
+
+- Acceptance criteria tied to journeys and product goals
+- Unit, integration, and end-to-end tests
+- AI evals and golden datasets where relevant
+- Performance budgets and regression checks
+- Visual or interaction validation notes
+- Quality gates in review or CI configuration
+
+Choose the mechanism that matches the output. Deterministic code gets tests. Model behavior gets evals. Do not substitute one for the other.
+
+## Minimum Useful Artifact
+
+- user-visible claim or risk being protected
+- testable acceptance criterion or scored eval behavior
+- instrument, dataset, threshold, and budget where relevant
+- command or demonstration that performs validation
+- owner and decision path when the bar fails
+
+## Recipe
+
+1. Inspect what quality artifacts exist and what CI already enforces.
+2. Understand what "good" means for this change: behavior, visual correctness, eval score, or budget.
+3. Identify gaps: missing acceptance criteria, unprotected critical paths, AI features with no eval, no performance threshold.
+4. Propose the smallest useful quality artifact before or alongside implementation.
+5. Write criteria that assert behavior, not implementation detail.
+6. Implement. Run the project's existing validation — do not invent a parallel suite.
+7. Fix failures or escalate when criteria cannot be met without a product decision.
+8. Update quality artifacts when behavior or criteria change.
+
+## Validation
+
+- Acceptance criteria are testable or demonstrable.
+- Critical paths have automated protection where the project supports it.
+- Failures produce actionable signal, not noise.
+- AI evals cover the behaviors users actually depend on.
+- CI going green is Pipelines. Meeting the bar is Quality.
+
+## Definition of Done
+
+Stated quality criteria are met and verified by the project's existing validation. Regressions are caught or explicitly accepted with documented rationale.
+
+## Agent Prompt
+
+Apply Quality First to this repository.
+
+Read acceptance criteria, existing tests, evals, and quality gates before implementing. Define what "good" means for this change — behavior, performance, visual correctness, or eval scores. Do not optimize toward an undefined target.
+
+Write or update tests and criteria before or alongside implementation. Use the project's existing validation commands. For probabilistic features, add or run evals; do not treat a unit test of the wrapper as the eval.
+
+Preserve intentional existing test patterns. Propose the smallest useful quality artifact. Fix validation failures or escalate. Update durable quality docs when criteria change.
+
+## Notes
+
+**Quality vs Pipelines:** Quality defines what should be validated. Pipelines run the validation.
+
+**Quality vs Product:** Product defines success after use and ships the analytics. Quality defines the bar that gates a release.
+
+**Quality vs Data:** Data owns domain invariants and dataset integrity. Quality owns release gates and eval datasets.
+
+**Navigation:** [Human essay](../articles/QUALITY.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/SECURITY.md
+++ b/_first/principles/SECURITY.md
@@ -1,0 +1,76 @@
+# Security First
+
+## Principle
+
+Identify what you are trusting, protecting, exposing, and allowing — proportionally to actual risk — before architecture makes security assumptions expensive to change.
+
+## Statement
+
+Security is not a phase at the end. It is a set of decisions about boundaries: who can access what, what data is sensitive, what inputs are untrusted, what an agent is allowed to touch. I scale rigor to risk — an internal tool and a regulated financial product do not get the same bar. I also do not pretend risk is zero.
+
+## Outcome
+
+Trust boundaries are documented. Auth rules are consistent and enforced at boundaries. Secrets are not committed and not logged. External inputs are validated. Agent permissions are scoped: read-only where possible, destructive actions gated, secrets minimized, human approval for high-risk operations.
+
+## Artifacts
+
+- Threat model or security constraints, scaled to project risk
+- Auth rules and permission models
+- Secret-handling rules and environment configuration docs
+- Data classification notes
+- Agent permission boundaries and approval requirements
+- Security scanning and dependency audit configuration
+
+Treat the agent as a service account: least privilege, and least agency. High-impact actions wait for a human.
+
+## Minimum Useful Artifact
+
+- protected assets and data classifications
+- principals, trust boundaries, and Security-owned authorization policy
+- untrusted inputs, secrets, and external dependencies
+- allowed, denied, and human-gated actions for agents
+- accepted risks, owner, and next review trigger
+
+## Recipe
+
+1. Inspect trust boundaries: public, authenticated, admin-only, internal-only.
+2. Understand what is stored, transmitted, logged, and exposed to agents.
+3. Identify gaps: auth drift, secrets in logs, untrusted input paths, overly broad agent tools.
+4. Propose the smallest security improvement or documentation fix.
+5. Define agent permissions the way you would define a role. Gate destructive work.
+6. Implement with existing project security patterns. Do not invent a parallel auth system.
+7. Validate with the project's scans and tests. Failures are fixed or explicitly accepted.
+8. Update security artifacts when behavior or the trust model changes.
+
+## Validation
+
+- Auth rules enforced at boundaries, not ad hoc per handler.
+- No secrets in code, logs, or agent-accessible files without justification.
+- Destructive and high-risk operations require human approval.
+- Security scans pass, or failures are accepted with rationale.
+
+## Definition of Done
+
+Trust boundaries and permissions are documented and implemented consistently. Agent access is scoped. Identified risks are addressed or explicitly accepted at the appropriate level.
+
+## Agent Prompt
+
+Apply Security First to this repository.
+
+Read security documentation, auth rules, permission models, and the target project's own security instructions before changing trust boundaries. Inspect how authentication, authorization, secrets, and external inputs are handled. Do not assume docs match implementation.
+
+Identify what data is sensitive and what actions are destructive. Scope your own permissions: prefer read-only inspection, avoid secrets, require human approval for destructive or security-consequential changes. Treat yourself as a service account, not a trusted colleague.
+
+Propose the smallest useful security fix or documentation update. Use existing project security patterns and scanning. Update durable security artifacts when the trust model changes.
+
+## Notes
+
+**Security vs Operations:** Security defines trust, protection, and permissions. Operations defines runtime visibility and recovery.
+
+**Security vs API:** API defines contracts at boundaries. Security defines who may invoke them and what they may access.
+
+**Security vs Architecture:** Architecture maps trust boundaries and dependencies. Security defines the protection and authorization policy across them.
+
+**Security vs Data:** Data maps classification, copies, retention, and deletion. Security owns access and protection policy.
+
+**Navigation:** [Human essay](../articles/SECURITY.md) · [Factory map](../ABOUT.md)

--- a/_first/principles/WORKFLOW.md
+++ b/_first/principles/WORKFLOW.md
@@ -1,0 +1,77 @@
+# Workflow First
+
+## Principle
+
+Make the path from intent to validated change explicit enough that humans, agents, and automation can cooperate without reconstructing the process every time.
+
+## Statement
+
+I care less about which methodology name is on the wall and more about whether work can move from idea to shipped, validated change. Who decides what? Where does state live? When does a human approve? If the path is only in people's heads, agents cannot help and humans cannot scale.
+
+## Outcome
+
+Work flows through a recognizable path: idea → plan → implement → review → pipeline signals → approval → release → learning. Handoffs have inputs and outputs. Work state lives in issues, tasks, or PRs — not only in chat. Human approval is explicit for destructive, security-sensitive, or product-consequential changes.
+
+## Artifacts
+
+- Issues, tasks, and pull requests as work state
+- Plans and review comments
+- ADRs and project docs for consequential decisions
+- CI results as automated validation signals
+- Agent notes that affect future work, promoted to durable context
+- Status updates (ephemeral coordination)
+
+Routing:
+
+- Consequential decision → project doc or ADR
+- Temporary coordination → chat or comment
+- Work state → issue, task, or PR
+- Automated validation → CI result
+
+## Minimum Useful Artifact
+
+- intent, owner, and visible work-state location
+- short plan and acceptance criteria for non-trivial work
+- actors plus the input and output of each handoff
+- required human gates and who can approve
+- validation, release, and learning destinations
+
+## Recipe
+
+1. Inspect current work state: issues, PRs, branches, CI status, and any plan.
+2. Understand the actor for this step: human, agent, CI, or production signal.
+3. Identify gaps: missing plan, missing owner, approval that lives only in chat, state that cannot be found.
+4. Propose before implementing on non-trivial work. Surface assumptions.
+5. Implement in small, reviewable chunks. Keep state in the issue or PR.
+6. Hand off to review with enough context for the next actor to continue.
+7. Run validation through existing pipelines. Respond to failures — fix or escalate.
+8. Obtain approval for consequential changes. Release. Capture learning in files when decisions changed.
+
+## Validation
+
+- Work state is visible without asking in chat.
+- Handoffs include enough context for the next actor to continue.
+- Consequential decisions are in files, not only in merged code.
+- Failed validation routes to a clear owner and next action.
+
+## Definition of Done
+
+The change moved through an explicit path. State is updated. Durable context reflects what was decided. The next actor can continue without reconstruction.
+
+## Agent Prompt
+
+Apply Workflow First to this repository.
+
+Read current work state — issues, PRs, plans — and project workflow documentation before acting. Identify actors, handoffs, approval boundaries, and where durable state lives. Do not rely on chat as the system of record.
+
+Take notes in durable project files when discoveries affect future work. Propose before implementing on non-trivial work. Implement in reviewable chunks. Use existing CI and review paths.
+
+Stop and ask a human for product scope, security-sensitive changes, and destructive operations. Update issues, PRs, and documentation as work progresses. Preserve intentional existing process decisions.
+
+## Notes
+
+**Workflow vs Pipelines:** Workflow is how actors respond. Pipelines are the automated format, test, build, and deploy mechanics.
+
+**Workflow vs Documentation:** Workflow determines when context is created. Documentation preserves it.
+
+**Navigation:** [Human essay](../articles/WORKFLOW.md) · [Factory map](../ABOUT.md)

--- a/_first/scripts/test_validate_docs.py
+++ b/_first/scripts/test_validate_docs.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Regression tests for FIRST's documentation validator."""
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import validate_docs
+
+
+class DocumentationValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.sourceRoot = validate_docs.root
+        self.temporary = tempfile.TemporaryDirectory(prefix="first-docs-test-")
+        self.fixtureRoot = Path(self.temporary.name)
+        for name in validate_docs.rootFiles:
+            shutil.copy2(self.sourceRoot / name, self.fixtureRoot / name)
+        for name in ("articles", "principles"):
+            shutil.copytree(self.sourceRoot / name, self.fixtureRoot / name)
+        validate_docs.root = self.fixtureRoot
+
+    def tearDown(self):
+        validate_docs.root = self.sourceRoot
+        self.temporary.cleanup()
+
+    def replace(self, relativePath, old, new):
+        path = self.fixtureRoot / relativePath
+        text = path.read_text(encoding="utf-8")
+        self.assertIn(old, text)
+        path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+    def testValidSet(self):
+        self.assertEqual(validate_docs.validate(), [])
+
+    def testMissingPair(self):
+        (self.fixtureRoot / "articles/DATA.md").unlink()
+        self.assertTrue(any("missing articles pair" in item for item in validate_docs.validate()))
+
+    def testPrincipleMismatch(self):
+        self.replace("articles/DATA.md", "## Principle", "## Principle\n\nDifferent principle.")
+        self.assertIn("principle mismatch: DATA.md", validate_docs.validate())
+
+    def testRequiredHeading(self):
+        self.replace("principles/DATA.md", "## Minimum Useful Artifact", "## Example")
+        self.assertTrue(any("missing heading 'Minimum Useful Artifact'" in item for item in validate_docs.validate()))
+
+    def testBrokenLocalLink(self):
+        self.replace("articles/DATA.md", "../ABOUT.md", "../MISSING.md")
+        self.assertTrue(any("broken local link" in item for item in validate_docs.validate()))
+
+    def testInvalidStatus(self):
+        self.replace("articles/DATA.md", "status: draft", "status: unknown")
+        self.assertTrue(any("invalid status" in item for item in validate_docs.validate()))
+
+    def testCanonicalOrder(self):
+        self.replace("README.md", "| 4 | Architecture |", "| 4 | Data |")
+        self.assertIn("canonical station list or order is wrong: README.md", validate_docs.validate())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/_first/scripts/validate_docs.py
+++ b/_first/scripts/validate_docs.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Validate the structural invariants of the FIRST documentation set."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+root = Path(__file__).resolve().parents[1]
+stations = [
+    "PRODUCT",
+    "JOURNEYS",
+    "DESIGN",
+    "ARCHITECTURE",
+    "DATA",
+    "API",
+    "DOCUMENTATION",
+    "WORKFLOW",
+    "PIPELINES",
+    "QUALITY",
+    "SECURITY",
+    "OPERATIONS",
+]
+rootFiles = ["README.md", "ABOUT.md", "AGENTS.md"]
+principleHeadings = [
+    "Principle",
+    "Statement",
+    "Outcome",
+    "Artifacts",
+    "Minimum Useful Artifact",
+    "Recipe",
+    "Validation",
+    "Definition of Done",
+    "Agent Prompt",
+    "Notes",
+]
+articleHeadings = [
+    "Principle",
+    "The Case",
+    "Product Leverage",
+    "Engineering Leverage",
+    "In an Agentic System",
+    'What "First" Does Not Mean',
+    "Spec",
+    "Further Reading",
+]
+linkPattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def section(text: str, heading: str) -> str | None:
+    match = re.search(
+        rf"^## {re.escape(heading)}\n\n(.+?)(?=\n\n## |\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    return match.group(1).strip() if match else None
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+
+    for name in rootFiles:
+        if not (root / name).is_file():
+            errors.append(f"missing root file: {name}")
+
+    expected = {f"{name}.md" for name in stations}
+    for folder in ("articles", "principles"):
+        actual = {path.name for path in (root / folder).glob("*.md")}
+        for name in sorted(expected - actual):
+            errors.append(f"missing {folder} pair: {folder}/{name}")
+        for name in sorted(actual - expected):
+            errors.append(f"unexpected station file: {folder}/{name}")
+
+    for name in stations:
+        articlePath = root / "articles" / f"{name}.md"
+        principlePath = root / "principles" / f"{name}.md"
+        if not articlePath.is_file() or not principlePath.is_file():
+            continue
+
+        article = articlePath.read_text(encoding="utf-8")
+        principle = principlePath.read_text(encoding="utf-8")
+
+        frontMatter = re.match(r"\A---\n(.+?)\n---\n", article, re.DOTALL)
+        if not frontMatter:
+            errors.append(f"missing front matter: {articlePath.relative_to(root)}")
+        else:
+            metadata = frontMatter.group(1)
+            for key in ("title", "status", "description"):
+                if not re.search(rf"^{key}:\s+.+$", metadata, re.MULTILINE):
+                    errors.append(
+                        f"missing front-matter key {key}: {articlePath.relative_to(root)}"
+                    )
+
+            expectedTitle = f"{name.title() if name != 'API' else 'API'} First"
+            titleMatch = re.search(r"^title:\s+(.+)$", metadata, re.MULTILINE)
+            statusMatch = re.search(r"^status:\s+(.+)$", metadata, re.MULTILINE)
+            if titleMatch and titleMatch.group(1) != expectedTitle:
+                errors.append(f"wrong title: {articlePath.relative_to(root)}")
+            if statusMatch and statusMatch.group(1) not in {"draft", "stable"}:
+                errors.append(f"invalid status: {articlePath.relative_to(root)}")
+
+        for heading in articleHeadings:
+            if section(article, heading) is None:
+                errors.append(
+                    f"missing heading '{heading}': {articlePath.relative_to(root)}"
+                )
+
+        for heading in principleHeadings:
+            if section(principle, heading) is None:
+                errors.append(
+                    f"missing heading '{heading}': {principlePath.relative_to(root)}"
+                )
+
+        articlePrinciple = section(article, "Principle")
+        operationalPrinciple = section(principle, "Principle")
+        if articlePrinciple != operationalPrinciple:
+            errors.append(f"principle mismatch: {name}.md")
+
+        if f"../principles/{name}.md" not in article:
+            errors.append(f"missing operational-spec link: {articlePath.relative_to(root)}")
+        if f"../articles/{name}.md" not in principle:
+            errors.append(f"missing human-essay link: {principlePath.relative_to(root)}")
+
+    for name in ("README.md", "ABOUT.md"):
+        path = root / name
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        catalog = section(text, "The twelve") or ""
+        pattern = (
+            r"^\|\s*\d+\s*\|\s*([^|]+?)\s*\|"
+            if name == "README.md"
+            else r"^\d+\.\s+\*\*([^*]+)\*\*"
+        )
+        listed = [item.upper() for item in re.findall(pattern, catalog, re.MULTILINE)]
+        if listed != stations:
+            errors.append(f"canonical station list or order is wrong: {name}")
+
+    markdownFiles = list(root.glob("*.md"))
+    markdownFiles += list((root / "articles").glob("*.md"))
+    markdownFiles += list((root / "principles").glob("*.md"))
+    for path in markdownFiles:
+        text = path.read_text(encoding="utf-8")
+        for href in linkPattern.findall(text):
+            if href.startswith(("http://", "https://", "#", "mailto:")):
+                continue
+            targetText = href.split("#", 1)[0]
+            target = (path.parent / targetText).resolve()
+            if not target.exists():
+                errors.append(
+                    f"broken local link in {path.relative_to(root)}: {href}"
+                )
+
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        print("FIRST documentation validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(
+        "FIRST documentation validation passed: "
+        "12 essay/spec pairs, required structure, parity, order, and local links."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/docu/content/docs/development/ai-workflow.mdx
+++ b/apps/docu/content/docs/development/ai-workflow.mdx
@@ -7,6 +7,8 @@ Development is **Cursor-first**. Claude Code follows the same rules and skills v
 
 Judgment lives in planning and review. Implementation is incremental. See [Engineering in the AI Era](https://gaboesquivel.com/blog/2026-02-engineering-ai-era). Index this site once — [Cursor Setup](/docs/development/cursor-setup). Versioning and how to update skills: [Cursor Skills](/docs/development/cursor-skills).
 
+The portable FIRST documentation in `_first/` is checked by the lint workflow. Run `python3 _first/scripts/validate_docs.py` locally to verify its station pairs, headings, front matter, principle parity, order, and local links. FIRST is a documentation artifact; it does not replace this repository's Cursor-first workflow.
+
 ## Sources of truth
 
 Always-on rules point at `apps/docu/content/docs/`. Glob rules are constraints only. **Read** the topic MDX for the task. Do not `@`-attach MDX from rules or skills. Root `AGENTS.md` is the cross-harness stub.
@@ -54,8 +56,6 @@ Tech skills (`fastify-v5`, `next-v16`, `vercel-react-v1`) usually attach themsel
 In-app chat (Fastify `/ai/chat`) defaults to Claude Haiku 4.5 — product model, not this workflow. Pass `model: "sonnet"` for Sonnet 4.6. See [Self-Hosted LLM](/docs/deployment/self-hosted-llm).
 
 CodeRabbit reviews PRs against project standards. Local gates: Biome, ESLint, [pre-commit security](/docs/architecture/security).
-
-The portable FIRST documentation in `_first/` is checked by the lint workflow. Run `python3 _first/scripts/validate_docs.py` locally to verify its station pairs, headings, front matter, principle parity, order, and local links. FIRST is a documentation artifact; it does not replace this repository's Cursor-first workflow.
 
 Point agents at MDX: `Using the patterns from @api, add an endpoint…`
 

--- a/apps/docu/content/docs/development/ai-workflow.mdx
+++ b/apps/docu/content/docs/development/ai-workflow.mdx
@@ -55,6 +55,8 @@ In-app chat (Fastify `/ai/chat`) defaults to Claude Haiku 4.5 — product model,
 
 CodeRabbit reviews PRs against project standards. Local gates: Biome, ESLint, [pre-commit security](/docs/architecture/security).
 
+The portable FIRST documentation in `_first/` is checked by the lint workflow. Run `python3 _first/scripts/validate_docs.py` locally to verify its station pairs, headings, front matter, principle parity, order, and local links. FIRST is a documentation artifact; it does not replace this repository's Cursor-first workflow.
+
 Point agents at MDX: `Using the patterns from @api, add an endpoint…`
 
 ## Related

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -21,3 +21,8 @@ reason = "Transitive sandbox, no fix available in ecosystem"
 [[IgnoredVulns]]
 id = "GHSA-gc25-3vc5-2jf9"
 reason = "Transitive sandbox, no fix available in ecosystem"
+
+# stream-json: jayson 4.x pins 1.9.1; patch is 3.5.0 (ESM breaking)
+[[IgnoredVulns]]
+id = "GHSA-528h-pc64-c93x"
+reason = "Transitive stream-json via jayson; fix is 3.5.0 (breaking), no 1.x patch"


### PR DESCRIPTION
## Summary
- Add the portable FIRST factory under `_first/` (essays, principles, validator) so agents load a station's principle before working, without naming this repo in the generic pack.
- Add Basilic-specific station instances in `_first/basilic/` (Fact / Drift / Unresolved) and wire load order in `AGENTS.md`: `_first/principles/X.md` then `_first/basilic/X.md`.
- Run FIRST validation in the lint workflow; ignore a new transitive `stream-json` DoS advisory (`GHSA-528h-pc64-c93x` via `jayson`) so pre-commit OSV can pass — no 1.x patch, 3.5.0 is a breaking ESM bump.

## Context
FIRST is a documentation artifact for humans and agents. Drop-in copy is `ABOUT.md` and `principles/` only. Project facts live in `_first/basilic/`, not in the generic principles. This does not replace Cursor rules, skills, or `apps/docu`.

## Breaking changes
None.

## Test plan
- [ ] `python3 _first/scripts/validate_docs.py` and `python3 -B _first/scripts/test_validate_docs.py` pass
- [ ] Lint workflow runs the FIRST validator step
- [ ] Generic `_first/ABOUT.md`, `_first/AGENTS.md`, `principles/`, and `articles/` do not name this repo or app paths
- [ ] `_first/basilic/` links use `../principles/X.md` and the twelve required headings are present
- [ ] Pre-commit OSV scan still passes with the new ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the FIRST documentation framework, including guidance for product, architecture, design, data, security, quality, workflows, pipelines, and operations.
  - Added Basilic-specific principles, workflows, validation guidance, and adoption instructions.
  - Expanded AI development workflow documentation with FIRST usage and local validation steps.

- **Bug Fixes**
  - Added automated checks to verify documentation structure, links, metadata, ordering, and consistency.

- **Tests**
  - Added regression coverage for valid and invalid documentation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->