### PR TITLE
feat(next): add typed no-op product event capture

### DIFF
--- a/_first/basilic/DATA.md
+++ b/_first/basilic/DATA.md
@@ -21,6 +21,7 @@ Core domain concepts have shared names and definitions. Each important dataset h
 - **Fact:** Sign-in methods: email, OAuth `account`, `wallet_identities`, `passkey_credentials`. TOTP is 2FA, not a sign-in method. Last-method guardrail on unlink.
 - **Fact:** Secrets at rest: API key and refresh `jti` via `hashToken`; magic-link/change-email codes HMAC-SHA256 with `ENCRYPTION_KEY`; OAuth tokens and web3/passkey callbacks AES-GCM
 - **Fact:** Migrations: [`../../apps/api/src/db/migrations/`](../../apps/api/src/db/migrations/) — generate from schema TypeScript; never hand-edit SQL
+- **Fact:** Product analytics events are not a store. `capture()` does not persist. No derived analytics copy is shipped (PostHog chosen, not installed).
 - **Unresolved:** domain glossary; retention, deletion, residency; identity/dedup beyond PK uniqueness
 - **Unresolved:** PostHog as a derived copy — decided, not installed (Product)
 
@@ -32,7 +33,7 @@ For `users` (and the same shape for any concept you touch):
 - identity: text primary key; email nullable (Web3-only accounts)
 - owner: Fastify API / PostgreSQL
 - writers: auth and account routes; readers: JWT session load, profile, `@repo/core` clients over HTTP
-- derived copies: none shipped (PostHog unmeasured)
+- derived copies: none shipped (product `capture()` is a no-op)
 - retention/deletion: **unresolved**
 - evolution: Drizzle migrations under `apps/api/src/db/migrations/`
 

--- a/_first/basilic/JOURNEYS.md
+++ b/_first/basilic/JOURNEYS.md
@@ -24,7 +24,8 @@ Actors, entry points, happy paths, alternates, error paths, permission gates, an
 - **Fact:** Account: last-method guardrail (`LAST_SIGN_IN_METHOD`); change/link email; OAuth/wallet/passkey link; API keys `bask_` shown once.
 - **Fact:** CLI: API key only; JWT auth endpoints excluded ([cli.mdx](../../apps/docu/content/docs/development/cli.mdx))
 - **Drift:** Web3 verify exists on Fastify; **web has no wallet UI**. Do not map a wallet-connect journey as shipped.
-- **Unresolved:** named journey files beyond auth MDX; mobile completion; in-product AI assistant as a mapped job (chat chrome exists)
+- **Fact:** Assistant demo job (web, in-shell chat): entry = composer or suggestion; happy = `getAccountInfo` output with `__render: 'user-info'` rendered; errors = stream/tool failure or stop; completion = `assistant_turn` with `outcome: 'completed'` **and** `accountRender: true`. A text-only successful reply is **not** this job. No GenUI CTA (`actions: {}`).
+- **Unresolved:** named journey files beyond auth MDX; mobile completion
 
 ```mermaid
 stateDiagram-v2
@@ -49,6 +50,17 @@ stateDiagram-v2
 - errors: invalid/expired codes, `TOKEN_REUSE_DETECTED`, `SESSION_NOT_FOUND`
 - gates: proxy (web) and Fastify JWT/API key — policy in SECURITY.md
 - completion: authenticated session; home loads. Wallet link after login is optional, not required.
+
+Assistant job (demo, same shape):
+
+- actor: web end user (signed in)
+- job: retrieve account context in-conversation
+- entry: `/` assistant chrome; suggestions “Who am I?” / “What can you help with?”
+- happy path: user sends a turn → `getAccountInfo` → `__render: 'user-info'` card
+- alternates: text-only assistant reply (turn completed, account job not)
+- errors: stream error; user stop
+- gates: proxy + Bearer JWT
+- completion: `user-info` rendered. Not “the model replied.”
 
 ## Recipe
 
@@ -77,7 +89,7 @@ Apply Journeys First to Basilic.
 
 Read authentication and account-linking MDX, `apps/web/proxy.ts`, Fastify auth/account routes, web auth UI, CLI, and tests. Map actors, entry points, states, errors, and completion. Compare documentation to actual behavior.
 
-Do not invent UI (including wallet connect). Do not invent a mobile journey. Surface missing states before implementing. Policy stays in Security. Propose the smallest useful update to journey artifacts in `apps/docu`. Update this instance when flows change.
+Do not invent UI (including wallet connect). Do not invent a mobile journey. The in-shell assistant account-context job is mapped (completion = `user-info` rendered). Surface missing states before implementing. Policy stays in Security. Propose the smallest useful update to journey artifacts in `apps/docu`. Update this instance when flows change.
 
 Treat CLI and coding agents as actors. If an actor is unnamed, do not invent a tool for them.
 

--- a/_first/basilic/OPERATIONS.md
+++ b/_first/basilic/OPERATIONS.md
@@ -19,10 +19,11 @@ Production behavior is observable at the level the project needs. Logs are struc
 - **Fact:** `GET /health` → `{ ok: true, dbReady }` — no auth, no deep probes (Resend/AI/IdP)
 - **Fact:** Deploy: [vercel.mdx](../../apps/docu/content/docs/deployment/vercel.mdx), [self-hosted-llm.mdx](../../apps/docu/content/docs/deployment/self-hosted-llm.mdx)
 - **Fact:** Rate limits are in-memory per API instance (Security names the policy; this station names the multi-replica blind spot)
+- **Fact:** `session_issued` is ops (Pino). Product `auth_succeeded` / `auth_failed` are no-op `capture()` calls, not log lines.
 - **Unresolved:** dashboards and alert rules; runbooks; verify-in-the-running-system after deploy
 - **Unresolved:** production identity/retries for in-product AI agents
 
-PostHog is Product, not operations. Do not file a missing success event as an ops ticket.
+PostHog is Product, not operations. Pino `session_issued` is ops. Product `auth_succeeded` / `auth_failed` are `capture()` calls, not log lines. Do not file a missing collected product event as an ops ticket.
 
 ## Minimum Useful Artifact
 

--- a/_first/basilic/PRODUCT.md
+++ b/_first/basilic/PRODUCT.md
@@ -20,9 +20,10 @@ The project has an inspectable answer to what, why, and how we will know. Non-go
 - **Fact:** New-device sign-in alerts are transactional email via Fastify `emailProvider` + `@repo/email`, not a notification product
 - **Fact:** Not a billed SaaS in files. No `PRODUCT.md` / PRD. Do not invent one to fill TAM.
 - **Fact:** Observed non-goals in code/docs: mobile not an API client; no web wallet UI; Cache Components off; `@repo/react` hooks handwritten
-- **Fact:** PostHog **chosen, not shipped** ([ADR 011](../../apps/docu/content/docs/adrs/011-product-analytics.mdx), [analytics.mdx](../../apps/docu/content/docs/architecture/analytics.mdx)). Event taxonomy **unmeasured**. No `@vercel/analytics`.
-- **Unresolved:** GTM (channel, first successful use); success metrics that can fail (not `pnpm qa`); TAM/LTV (toolkit — say so); named decision owners for the product bet
-- **Unresolved:** keep / iterate / kill board
+- **Fact:** PostHog **chosen, not installed**. No SDK, env keys, or sink. Product events are **specified** in types + [analytics.mdx](../../apps/docu/content/docs/architecture/analytics.mdx) and **instrumented** at the web boundary via `apps/web/lib/analytics.ts` `capture()`. They are **not collected** and therefore **not measured**. No `@vercel/analytics`.
+- **Fact:** Two demo questions are specified: (1) auth — did sign-in complete or did a visible attempt fail (`auth_succeeded` / `auth_failed` by `method`); (2) assistant — did this turn render `__render: 'user-info'` (`assistant_turn` with `accountRender`). Factory GTM, GenUI act, demo surfaces, session revoke, cost-per-job: **unmeasured** (not instrumented).
+- **Unresolved:** GTM (channel, first successful use); PostHog install / consent / retention; success metrics that can fail (not `pnpm qa`); TAM/LTV (toolkit — say so); named decision owners for the product bet
+- **Unresolved:** keep / iterate / kill board; whether adopters copy `lib/analytics` (qualitative — no event can evaluate that)
 
 `pnpm qa` going green is Quality/Pipelines, not product success.
 
@@ -33,8 +34,8 @@ The project has an inspectable answer to what, why, and how we will know. Non-go
 - goal: portable starter with self-hosted Web2/Web3 auth and Cursor-first workflow
 - non-goals: listed above as observed, not a ratified PRD
 - audience/channel/first use: **unresolved** beyond “fork and run”
-- metrics: **unmeasured**
-- events: **unmeasured** (PostHog chosen, not shipped)
+- metrics: auth and assistant jobs **instrumented, not collected** (cannot be queried yet)
+- events: `auth_succeeded`, `auth_failed`, `assistant_turn` — specified + instrumented, no sink
 - owners: **unresolved**
 
 ## Recipe
@@ -52,7 +53,7 @@ The project has an inspectable answer to what, why, and how we will know. Non-go
 
 - A new contributor can answer what we are building from README + this file: a starter/toolkit with a demo web app. Who/why/how-we-will-know beyond that is unresolved.
 - Success metrics can fail. They are not CI green. Currently unmeasured.
-- Named metrics have events, or are marked unmeasured (PostHog).
+- Named metrics have events, or are marked unmeasured. Auth/assistant are instrumented without a sink (not measured).
 - GTM is named at the level the product needs, or marked unresolved.
 - No silent product decisions in code without a note or open question.
 
@@ -64,7 +65,7 @@ Product intent is documented or explicitly deferred with named owners. Implement
 
 Apply Product First to Basilic.
 
-Read root README, `apps/docu/content/docs/index.mdx`, analytics MDX and ADR 011, and what the web, mobile, and API actually do. Do not assume documentation is complete. PostHog is not installed — do not claim events fire.
+Read root README, `apps/docu/content/docs/index.mdx`, analytics MDX and ADR 011, and what the web, mobile, and API actually do. Do not assume documentation is complete. PostHog is not installed. `capture()` is a no-op — do not claim events are collected or measured.
 
 Preserve intentional existing product choices. Do not silently decide scope, priorities, pricing, TAM, LTV, event names, or GTM. This is a toolkit, not a billed product in files — say so rather than filling finance blanks.
 

--- a/apps/docu/content/docs/adrs/011-product-analytics.mdx
+++ b/apps/docu/content/docs/adrs/011-product-analytics.mdx
@@ -14,7 +14,7 @@ The monorepo includes a Next.js web app (`apps/web`) and an Expo mobile app (`ap
 - **Respect privacy** with EU/US regions and optional self-hosting
 - **Stay within budget** with a generous free tier or predictable costs
 
-We do **not** currently ship a product-analytics SDK. `@vercel/analytics` is not in the repo. PostHog is the **chosen** vendor and is **not installed** yet.
+We do **not** currently ship a product-analytics SDK. `@vercel/analytics` is not in the repo. PostHog is the **chosen** vendor and is **not installed**. The web app has a typed no-op `capture()` (`apps/web/lib/analytics.ts`): events are **instrumented, not collected**.
 
 ## Considered Options
 
@@ -84,7 +84,7 @@ Third-party hosted analytics.
 
 ## Decision
 
-We adopt **PostHog** for product analytics across web and mobile. **This ADR records the choice; the SDKs are not installed.** Do not treat docs or Pino `session_issued` as product analytics.
+We adopt **PostHog** for product analytics across web and mobile. **This ADR records the choice; the SDKs are not installed.** Do not treat Pino `session_issued` as product analytics. Web `capture()` is not a PostHog integration.
 
 ### TLDR: Comparison Table
 
@@ -117,7 +117,7 @@ We adopt **PostHog** for product analytics across web and mobile. **This ADR rec
 
 - **Web**: `posthog-js` (or `posthog-node`), deferred load via `next/dynamic`
 - **Mobile**: `posthog-react-native` with `PostHogProvider`
-- **Events**: Page/screen views (auto), key actions (signup, feature usage), custom properties for segmentation
+- **Events**: Typed `capture()` at the web boundary for auth success/failure and assistant turns. No autocapture, replay, or identify until a later install PR. Taxonomy: [Product analytics](/docs/architecture/analytics).
 
 ## Related Documentation
 

--- a/apps/docu/content/docs/adrs/index.mdx
+++ b/apps/docu/content/docs/adrs/index.mdx
@@ -43,7 +43,7 @@ Development tooling and code standards:
 
 Product usage and observability:
 
-- **[ADR 011: Product Analytics](/docs/adrs/011-product-analytics)** - PostHog for web and mobile product analytics, funnels, retention, session replay, feature flags
+- **[ADR 011: Product Analytics](/docs/adrs/011-product-analytics)** - PostHog chosen, not installed; web `capture()` is a typed no-op
 
 ## Deployment & CI/CD
 

--- a/apps/docu/content/docs/architecture/ai.mdx
+++ b/apps/docu/content/docs/architecture/ai.mdx
@@ -67,7 +67,7 @@ The web app uses `useChatFromConfig` (`@repo/react`) → `POST {baseUrl}/ai/chat
 { "__render": "user-info", "spec": { "root": "...", "elements": { ... } }, "summary": "..." }
 ```
 
-`assistant-chat.tsx` matches `tool-getAccountInfo` parts and renders via `user-info-catalog.tsx`. Do not rename the tool or change the output shape without updating the web UI.
+`assistant-chat.tsx` matches `tool-getAccountInfo` parts and renders via `user-info-catalog.tsx`. Do not rename the tool or change the output shape without updating the web UI. `__render: 'user-info'` is the product name for the demo account-context job. Product analytics records `assistant_turn` with `accountRender` when that surface is present — not merely when the assistant replies. See [Product analytics](/docs/architecture/analytics).
 
 Composer send (textarea + suggestions) is disabled while `status !== 'ready'`; stop remains available during `streaming`.
 

--- a/apps/docu/content/docs/architecture/analytics.mdx
+++ b/apps/docu/content/docs/architecture/analytics.mdx
@@ -1,11 +1,49 @@
 ---
 title: "Product Analytics"
-description: "PostHog is the chosen product analytics platform. It is not installed yet."
+description: "PostHog is chosen, not installed. Web capture() is a typed no-op: specified and instrumented, not collected."
 ---
 
-**PostHog is selected, not shipped.** There is no `posthog-js` / `posthog-react-native` dependency and no `apps/web/lib/analytics/` implementation. Auth success and feature-usage events must not be invented as Pino substitutes. Decision: [ADR 011](/docs/adrs/011-product-analytics). Operations logs are [Logging](/docs/architecture/logging).
+**PostHog is selected, not shipped.** There is no `posthog-js` / `posthog-react-native` dependency and no PostHog env keys. Decision: [ADR 011](/docs/adrs/011-product-analytics). Operations logs are [Logging](/docs/architecture/logging).
 
-When we install it, intended use is product analytics on web and mobile (events, funnels, replay, flags, experiments) — not engineering health.
+Web product events go through `apps/web/lib/analytics.ts` `capture()`. That helper has **no sink**. Auth and assistant jobs are **specified** (types + this page) and **instrumented** (call sites exist). They are **not collected** and **not measured**. Do not invent Pino substitutes for product events. Do not treat a no-op `capture()` as measurement.
+
+| State | Meaning | Auth / assistant |
+| --- | --- | --- |
+| specified | Event and props named | yes |
+| instrumented | Call site exists | yes |
+| collected | A sink receives the event | no |
+| measured | Queryable; used to keep / iterate / kill | no |
+
+## Product questions
+
+1. **Auth:** Did sign-in complete, or did a visible attempt fail? (`auth_succeeded` / `auth_failed` by `method`)
+2. **Assistant:** Did this turn render the account surface (`__render: 'user-info'`)? Not “the model replied.”
+
+Observable facts only. Rendering `user-info` is not user acceptance.
+
+## Event contract (`capture()`)
+
+Discriminated union. Unknown names and invalid property combinations do not type-check. `method` uses the same literals as session `signInMethod` (`magic_link`, `oauth_google`, `oauth_github`, `oauth_facebook`, `oauth_twitter`, `passkey`, `web3_eip155`, `web3_solana`).
+
+| Event | Fields | When |
+| --- | --- | --- |
+| `auth_succeeded` | `method` | After login cookies/tokens are set. Not refresh, proxy rotation, change-email, or `update-tokens`. |
+| `auth_failed` | `method`, `errorCode` | Where a catalog `code` still exists (callback `catch`, magic verify fail). Not login-banner mount (`?message=` is display copy). |
+| `assistant_turn` | `outcome`: `completed` \| `stopped` \| `error`; `accountRender`: boolean | One event per submitted user turn. Account-context job = `completed` **and** `accountRender: true`. |
+
+No prompt text, email, or tokens in props.
+
+```ts
+import { capture } from '@/lib/analytics'
+
+capture({ name: 'auth_succeeded', method: 'magic_link' })
+```
+
+## Later (not in the TypeScript union)
+
+Documented here only until they ship: `auth_method_selected`, `session_revoked`, `demo_feature_used`, `genui_acted`; props such as TTFU, tool names, token usage, stream duration. Token/latency/tool execution stay [ops](/docs/architecture/logging) until a product question needs a copy on the event.
+
+When PostHog is installed (separate PR): SDK, env keys, privacy copy that matches collection. Call sites stay `capture()`.
 
 ## PostHog Cloud Pricing (planned)
 
@@ -25,19 +63,17 @@ The free tier resets every month. See [PostHog pricing](https://posthog.com/pric
 
 ### Web (Next.js)
 
-- Use `posthog-js` (or `posthog-node` for server-side events)
+- Use `posthog-js` (or `posthog-node` for server-side events) **inside** `capture()` later
 - Defer loading with `next/dynamic` so analytics do not block the UI
+- No autocapture or session replay in v1 of that PR
 
 ### Mobile (Expo)
 
-- Use `posthog-react-native`
+- Use `posthog-react-native` when mobile product questions exist
 - Wrap the app with `PostHogProvider`
-
-### Events to track later
-
-Taxonomy is unmeasured until install: `auth_method_selected`, `auth_succeeded`, `auth_failed`, `session_revoked`, `demo_feature_used`, plus journey events only with a mapping.
 
 ## Related Documentation
 
 - [ADR 011: Product Analytics](/docs/adrs/011-product-analytics)
 - [Logging](/docs/architecture/logging)
+- [AI](/docs/architecture/ai) — assistant `__render: 'user-info'` job

--- a/apps/docu/content/docs/architecture/index.mdx
+++ b/apps/docu/content/docs/architecture/index.mdx
@@ -31,7 +31,7 @@ sequenceDiagram
 - [Frontend](/docs/architecture/frontend) — Next.js 16, React 19, Tailwind 4, Web3 hooks
 - [Error handling](/docs/architecture/error-handling) — `@repo/error`, log-only capture (Sentry installed, inactive)
 - [Logging](/docs/architecture/logging) — Pino / console, `reqId`
-- [Product analytics](/docs/architecture/analytics) — PostHog chosen, not shipped
+- [Product analytics](/docs/architecture/analytics) — PostHog chosen, not shipped; web instrumented, not collected
 - [Security](/docs/architecture/security) — Secrets, CVE scans, DeepSec
 - [ESM & TypeScript](/docs/architecture/esm-strategy) — TypeScript 7, dual-mode exports
 - [Portability](/docs/architecture/portability) — Host anywhere

--- a/apps/docu/content/docs/architecture/logging.mdx
+++ b/apps/docu/content/docs/architecture/logging.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Logging"
-description: "Ops logging is Pino (API/Fastify, Next server) and a console wrapper (browser). Join key is reqId. Product analytics is separate and not installed."
+description: "Ops logging is Pino (API/Fastify, Next server) and a console wrapper (browser). Join key is reqId. Product analytics is a separate no-op capture(), not logs."
 ---
 
 ```ts
@@ -45,6 +45,6 @@ Shallow sanitize of top-level keys (`password`, `token`, `secret`, `email`, …)
 
 ## Operational signals (not product analytics)
 
-Auth/email lines (low cardinality): `session_issued`, `auth_verify_failed`, `auth_locked`, `email_skipped`, `email_send_failed`, `auth_callback_failed`, `auth_proxy_refresh_failed`. No success-send or `auth_succeeded` logs (those belong to PostHog later).
+Auth/email lines (low cardinality): `session_issued`, `auth_verify_failed`, `auth_locked`, `email_skipped`, `email_send_failed`, `auth_callback_failed`, `auth_proxy_refresh_failed`. No success-send or product `auth_succeeded` log lines — product auth events are no-op `capture()` calls, not Pino.
 
 Product analytics is not logging: [Analytics](/docs/architecture/analytics). Failures: [Error Handling](/docs/architecture/error-handling).

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -87,6 +87,7 @@ apps/web/
 │   └── (dashboard)/       # Authenticated routes
 ├── app/providers.tsx      # QueryClient, ApiProvider, createClient (JWT mode)
 ├── lib/auth/              # auth-client, auth-server, jwt-utils
+├── lib/analytics.ts       # typed capture() — no-op sink
 ├── lib/env.ts             # Environment validation
 └── proxy.ts               # Auth gate and token refresh on navigation
 ```
@@ -104,6 +105,8 @@ See `app/providers.tsx`.
 
 Auth callbacks exchange credentials with Fastify and set the `api.session` cookie. Clients call Fastify directly; Next.js routes exist for cookie integration only.
 
+Product events (`capture` in `lib/analytics.ts`) are typed no-ops — instrumented, not collected. See [Product analytics](../docu/content/docs/architecture/analytics.mdx).
+
 See [Authentication Architecture](../docu/content/docs/architecture/authentication.mdx).
 
 ## Testing
@@ -114,3 +117,4 @@ Playwright E2E only (`e2e/**/*.spec.ts`). See [E2E Testing](../docu/content/docs
 
 - [Monorepo Structure](../docu/content/docs/architecture/monorepo.mdx)
 - [Frontend Architecture](../docu/content/docs/architecture/frontend.mdx)
+- [Product analytics](../docu/content/docs/architecture/analytics.mdx)

--- a/apps/web/app/auth/callback/magiclink/route.ts
+++ b/apps/web/app/auth/callback/magiclink/route.ts
@@ -1,6 +1,7 @@
 import { ApiError } from '@repo/core'
 import { redirect } from 'next/navigation'
 import { NextResponse } from 'next/server'
+import { capture } from '@/lib/analytics'
 import { setAuthCookiesOnResponse } from '@/lib/auth/auth-server'
 import { createBffClient, logAuthBffFailure } from '@/lib/auth/bff-client'
 import { extractTokens } from '@/lib/auth/callback-utils'
@@ -66,10 +67,14 @@ export async function GET(request: Request) {
         body: { verificationId, token },
       })
       const tokens = extractTokens(response)
-      if (!tokens) redirect(`/auth/login?message=${encodeURIComponent('FAILED_VERIFY')}`)
+      if (!tokens) {
+        capture({ name: 'auth_failed', method: 'magic_link', errorCode: 'FAILED_VERIFY' })
+        redirect(`/auth/login?message=${encodeURIComponent('FAILED_VERIFY')}`)
+      }
 
       const redirectResponse = NextResponse.redirect(new URL(callbackURL ?? '/', request.url), 303)
       setAuthCookiesOnResponse(redirectResponse, tokens)
+      capture({ name: 'auth_succeeded', method: 'magic_link' })
       return redirectResponse
     } catch (error) {
       logAuthBffFailure({ error, reqId, method: 'magiclink' })
@@ -83,6 +88,7 @@ export async function GET(request: Request) {
               : 'INVALID_TOKEN'
             : 'FAILED_VERIFY'
           : 'FAILED_VERIFY'
+      capture({ name: 'auth_failed', method: 'magic_link', errorCode: code })
       return NextResponse.redirect(
         new URL(`/auth/login?message=${encodeURIComponent(code)}`, request.url),
         303,
@@ -93,6 +99,8 @@ export async function GET(request: Request) {
   if (hasValidVerificationId && verificationId)
     return renderCodeEntryForm(verificationId, callbackURL)
 
+  if (verificationId || token)
+    capture({ name: 'auth_failed', method: 'magic_link', errorCode: 'INVALID_TOKEN' })
   redirect(`/auth/login?message=${encodeURIComponent('INVALID_TOKEN')}`)
 }
 
@@ -104,6 +112,7 @@ export async function POST(request: Request) {
   const callbackURL = isSafeCallbackUrl(rawCallback ?? null, request.url)
 
   if (!verificationId || !token || !uuidLike.test(verificationId) || !sixDigitCode.test(token)) {
+    capture({ name: 'auth_failed', method: 'magic_link', errorCode: 'INVALID_CODE' })
     const backUrl = verificationId
       ? `/auth/callback/magiclink?verificationId=${encodeURIComponent(verificationId)}&callbackURL=${encodeURIComponent(callbackURL)}&message=${encodeURIComponent('INVALID_CODE')}`
       : `/auth/callback/magiclink?message=${encodeURIComponent('INVALID_CODE')}`
@@ -116,10 +125,14 @@ export async function POST(request: Request) {
       body: { verificationId, token },
     })
     const tokens = extractTokens(response)
-    if (!tokens) redirect(`/auth/login?message=${encodeURIComponent('FAILED_VERIFY')}`)
+    if (!tokens) {
+      capture({ name: 'auth_failed', method: 'magic_link', errorCode: 'FAILED_VERIFY' })
+      redirect(`/auth/login?message=${encodeURIComponent('FAILED_VERIFY')}`)
+    }
 
     const redirectResponse = NextResponse.redirect(new URL(callbackURL ?? '/', request.url), 303)
     setAuthCookiesOnResponse(redirectResponse, tokens)
+    capture({ name: 'auth_succeeded', method: 'magic_link' })
     return redirectResponse
   } catch (error) {
     logAuthBffFailure({ error, reqId, method: 'magiclink' })
@@ -129,6 +142,7 @@ export async function POST(request: Request) {
           ? 'INVALID_TOKEN'
           : 'FAILED_VERIFY'
         : 'FAILED_VERIFY'
+    capture({ name: 'auth_failed', method: 'magic_link', errorCode: code })
     return NextResponse.redirect(
       new URL(`/auth/login?message=${encodeURIComponent(code)}`, request.url),
       303,

--- a/apps/web/app/auth/callback/oauth/twitter/route.ts
+++ b/apps/web/app/auth/callback/oauth/twitter/route.ts
@@ -1,9 +1,8 @@
 import { cookies } from 'next/headers'
 import { redirect, unstable_rethrow } from 'next/navigation'
-import { NextResponse } from 'next/server'
-import { setAuthCookiesOnResponse } from '@/lib/auth/auth-server'
+import { capture } from '@/lib/analytics'
 import { createBffClient, logAuthBffFailure } from '@/lib/auth/bff-client'
-import { extractTokens, getOAuthRedirectTarget } from '@/lib/auth/callback-utils'
+import { completeOAuthCallback } from '@/lib/auth/callback-utils'
 import { parseAuthCookie } from '@/lib/auth/parse-auth-cookie'
 import { env } from '@/lib/env'
 
@@ -26,7 +25,10 @@ export async function GET(request: Request) {
   const code = searchParams.get('code')
   const state = searchParams.get('state')
 
-  if (!code || !state) redirect(`/auth/login?message=${encodeURIComponent('missing_params')}`)
+  if (!code || !state) {
+    capture({ name: 'auth_failed', method: 'oauth_twitter', errorCode: 'missing_params' })
+    redirect(`/auth/login?message=${encodeURIComponent('missing_params')}`)
+  }
 
   const cookieStore = await cookies()
   const { token } = parseAuthCookie(cookieStore.get(env.NEXT_PUBLIC_AUTH_COOKIE_NAME)?.value)
@@ -37,20 +39,18 @@ export async function GET(request: Request) {
       body: { code, state },
       throwOnError: true,
     })
-    const tokens = extractTokens(response)
-    if (!tokens) return redirect(`/auth/login?message=${encodeURIComponent('oauth_failed')}`)
-
-    const redirectResponse = NextResponse.redirect(
-      new URL(getOAuthRedirectTarget(response), request.url),
-      303,
-    )
-    setAuthCookiesOnResponse(redirectResponse, tokens)
-    return redirectResponse
+    return completeOAuthCallback({
+      request,
+      response,
+      failureMessage: 'oauth_failed',
+      method: 'oauth_twitter',
+    })
   } catch (error) {
     unstable_rethrow(error)
     logAuthBffFailure({ error, reqId, method: 'oauth_twitter' })
     const rawMessage = error instanceof Error ? error.message : 'Twitter sign-in failed'
     const errorCode = mapAuthError(rawMessage)
+    capture({ name: 'auth_failed', method: 'oauth_twitter', errorCode })
     redirect(`/auth/login?message=${encodeURIComponent(errorCode)}`)
   }
 }

--- a/apps/web/app/auth/callback/passkey/route.ts
+++ b/apps/web/app/auth/callback/passkey/route.ts
@@ -1,5 +1,6 @@
 import { redirect, unstable_rethrow } from 'next/navigation'
 import { NextResponse } from 'next/server'
+import { capture } from '@/lib/analytics'
 import { setAuthCookiesOnResponse } from '@/lib/auth/auth-server'
 import { createBffClient, logAuthBffFailure } from '@/lib/auth/bff-client'
 import { extractTokens } from '@/lib/auth/callback-utils'
@@ -15,7 +16,10 @@ export async function GET(request: Request) {
       ? rawCallbackUrl
       : null
 
-  if (!code) redirect(`/auth/login?message=${encodeURIComponent('INVALID_OR_EXPIRED_CODE')}`)
+  if (!code) {
+    capture({ name: 'auth_failed', method: 'passkey', errorCode: 'INVALID_OR_EXPIRED_CODE' })
+    redirect(`/auth/login?message=${encodeURIComponent('INVALID_OR_EXPIRED_CODE')}`)
+  }
 
   const origin = new URL(request.url).origin
   const { client, reqId } = createBffClient({
@@ -28,15 +32,20 @@ export async function GET(request: Request) {
       body: { code },
     })
     const tokens = extractTokens(response)
-    if (!tokens) redirect(`/auth/login?message=${encodeURIComponent('INVALID_OR_EXPIRED_CODE')}`)
+    if (!tokens) {
+      capture({ name: 'auth_failed', method: 'passkey', errorCode: 'INVALID_OR_EXPIRED_CODE' })
+      redirect(`/auth/login?message=${encodeURIComponent('INVALID_OR_EXPIRED_CODE')}`)
+    }
 
     const redirectUrl = callbackUrl ?? '/'
     const redirectResponse = NextResponse.redirect(new URL(redirectUrl, request.url), 303)
     setAuthCookiesOnResponse(redirectResponse, tokens)
+    capture({ name: 'auth_succeeded', method: 'passkey' })
     return redirectResponse
   } catch (err) {
     unstable_rethrow(err)
     logAuthBffFailure({ error: err, reqId, method: 'passkey' })
+    capture({ name: 'auth_failed', method: 'passkey', errorCode: 'INVALID_OR_EXPIRED_CODE' })
     return NextResponse.redirect(
       new URL(`/auth/login?message=${encodeURIComponent('INVALID_OR_EXPIRED_CODE')}`, request.url),
       303,

--- a/apps/web/app/auth/callback/web3/route.ts
+++ b/apps/web/app/auth/callback/web3/route.ts
@@ -1,8 +1,19 @@
 import { redirect, unstable_rethrow } from 'next/navigation'
 import { NextResponse } from 'next/server'
+import { capture, type SignInMethod } from '@/lib/analytics'
 import { setAuthCookiesOnResponse } from '@/lib/auth/auth-server'
 import { createBffClient, logAuthBffFailure } from '@/lib/auth/bff-client'
 import { extractTokens } from '@/lib/auth/callback-utils'
+import { decodeJwtToken } from '@/lib/auth/jwt-utils'
+
+function web3MethodFromAccessToken({ token }: { token: string }): SignInMethod | null {
+  const wal = decodeJwtToken({ token })?.wal
+  if (!wal || typeof wal !== 'object' || !('chain' in wal)) return null
+  const chain = (wal as { chain?: unknown }).chain
+  if (chain === 'eip155') return 'web3_eip155'
+  if (chain === 'solana') return 'web3_solana'
+  return null
+}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -23,6 +34,8 @@ export async function GET(request: Request) {
     const redirectUrl = callbackURL ?? '/'
     const redirectResponse = NextResponse.redirect(new URL(redirectUrl, request.url), 303)
     setAuthCookiesOnResponse(redirectResponse, tokens)
+    const method = web3MethodFromAccessToken({ token: tokens.token })
+    if (method) capture({ name: 'auth_succeeded', method })
     return redirectResponse
   } catch (error) {
     unstable_rethrow(error)

--- a/apps/web/app/auth/login/login-actions.tsx
+++ b/apps/web/app/auth/login/login-actions.tsx
@@ -14,6 +14,8 @@ import { useRouter } from 'next/navigation'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 import { Facebook, GitHub, Google, Passkey, Twitter } from '@/components/icons'
+import { capture } from '@/lib/analytics'
+import { getApiErrorCode } from '@/lib/auth/api-error'
 import { updateAuthTokens } from '@/lib/auth/auth-client'
 import { LoginForm } from './login-form'
 import { PasskeyShortcut } from './passkey-shortcut'
@@ -175,6 +177,13 @@ export function LoginActions({ initialError }: LoginActionsProps): React.JSX.Ele
     error: passkeyError,
     isPending: isPasskeyPending,
   } = usePasskeyAuth()
+  const capturePasskeyFailed = (err: unknown) => {
+    capture({
+      name: 'auth_failed',
+      method: 'passkey',
+      errorCode: getApiErrorCode(err) ?? 'PASSKEY_FAILED',
+    })
+  }
   const { email: discoveryEmail } = usePasskeyDiscovery()
   const webauthnAvailable = useWebAuthnAvailable()
   const anyPending = isOAuthPending || isPasskeyPending || isGooglePending
@@ -209,17 +218,21 @@ export function LoginActions({ initialError }: LoginActionsProps): React.JSX.Ele
           email={discoveryEmail}
           onUsePasskey={() => {
             setLastAuthMethod('passkey')
-            startPasskeyAuth({
-              onSuccess: async ({ token, refreshToken }) => {
-                try {
-                  await updateAuthTokens({ token, refreshToken })
-                } catch (err) {
-                  toast.error(err instanceof Error ? err.message : 'Failed to complete sign-in')
-                  return
-                }
-                router.push('/')
+            startPasskeyAuth(
+              {
+                onSuccess: async ({ token, refreshToken }) => {
+                  try {
+                    await updateAuthTokens({ token, refreshToken })
+                  } catch (err) {
+                    toast.error(err instanceof Error ? err.message : 'Failed to complete sign-in')
+                    return
+                  }
+                  capture({ name: 'auth_succeeded', method: 'passkey' })
+                  router.push('/')
+                },
               },
-            })
+              { onError: capturePasskeyFailed },
+            )
           }}
           onUseAnotherMethod={() =>
             discoveryEmail && setOptedOutEmails(prev => new Set(prev).add(discoveryEmail))
@@ -232,6 +245,7 @@ export function LoginActions({ initialError }: LoginActionsProps): React.JSX.Ele
         onVerifySuccess={async ({ token, refreshToken }) => {
           try {
             await updateAuthTokens({ token, refreshToken })
+            capture({ name: 'auth_succeeded', method: 'magic_link' })
             router.push('/')
           } catch (err) {
             toast.error(err instanceof Error ? err.message : 'Failed to complete sign-in')
@@ -252,7 +266,7 @@ export function LoginActions({ initialError }: LoginActionsProps): React.JSX.Ele
             isOAuthPending={isOAuthPending}
             isGooglePending={isGooglePending}
             webauthnAvailable={webauthnAvailable}
-            startPasskeyAuth={startPasskeyAuth}
+            startPasskeyAuth={opts => startPasskeyAuth(opts, { onError: capturePasskeyFailed })}
             isPasskeyPending={isPasskeyPending}
           />
         }

--- a/apps/web/app/auth/login/login-form.tsx
+++ b/apps/web/app/auth/login/login-form.tsx
@@ -18,6 +18,7 @@ import {
 import { cn } from '@repo/ui/lib/utils'
 import { useState } from 'react'
 import { z } from 'zod'
+import { capture } from '@/lib/analytics'
 import { getApiErrorCode, isRateLimitApiError } from '@/lib/auth/api-error'
 import { getAuthErrorMessage } from '@/lib/auth/auth-error-messages'
 import { LoginCodeView } from './login-code-view'
@@ -113,6 +114,11 @@ export function LoginForm({
     },
     onError: error => {
       const code = getApiErrorCode(error)
+      capture({
+        name: 'auth_failed',
+        method: 'magic_link',
+        errorCode: code ?? 'FAILED_VERIFY',
+      })
       if (code === 'INVALID_TOKEN' || code === 'EXPIRED_TOKEN')
         setCodeError('Invalid or expired code. Please try again or request a new one.')
       else

--- a/apps/web/app/auth/login/use-google-one-tap.ts
+++ b/apps/web/app/auth/login/use-google-one-tap.ts
@@ -7,6 +7,7 @@ import { useMutation } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { capture } from '@/lib/analytics'
 import { updateAuthTokens } from '@/lib/auth/auth-client'
 import { getAuthErrorMessage } from '@/lib/auth/auth-error-messages'
 import { env } from '@/lib/env'
@@ -140,8 +141,18 @@ export function useGoogleOneTap({
       try {
         const data = await verifyIdToken(credential)
         await updateAuthTokens({ token: data.token, refreshToken: data.refreshToken })
+        capture({ name: 'auth_succeeded', method: 'oauth_google' })
         router.push('/')
       } catch (err) {
+        const errorCode =
+          err instanceof ApiError
+            ? err.status === 503
+              ? 'oauth_not_configured'
+              : err.status === 429
+                ? 'rate_limit_exceeded'
+                : 'oauth_failed_google'
+            : 'oauth_failed_google'
+        capture({ name: 'auth_failed', method: 'oauth_google', errorCode })
         if (err instanceof ApiError)
           if (err.status === 503) toast.error(getAuthErrorMessage('oauth_not_configured'))
           else if (err.status === 429) toast.error(getAuthErrorMessage('rate_limit_exceeded'))

--- a/apps/web/components/assistant/assistant-chat.tsx
+++ b/apps/web/components/assistant/assistant-chat.tsx
@@ -20,6 +20,7 @@ import { Input, PromptInputSubmit, PromptInputTextarea } from 'components/assist
 import { userInfoRegistry } from 'components/assistant/user-info-catalog'
 import { MessageCircleIcon } from 'lucide-react'
 import { type FormEvent, type ReactNode, useEffect, useRef, useState } from 'react'
+import { capture } from '@/lib/analytics'
 
 const suggestions = ['Who am I?', 'What can you help with?']
 
@@ -37,6 +38,28 @@ function isUserInfoSpecOutput(
   )
 }
 
+function partsHaveAccountRender(parts: unknown): boolean {
+  if (!Array.isArray(parts)) return false
+  return parts.some(part => {
+    if (!part || typeof part !== 'object' || !('type' in part)) return false
+    const type = (part as { type?: unknown }).type
+    if (typeof type !== 'string' || !type.startsWith('tool-')) return false
+    const toolName = type.replace(/^tool-/, '')
+    if (toolName !== 'getAccountInfo') return false
+    if (!('state' in part) || (part as { state?: unknown }).state !== 'output-available')
+      return false
+    return isUserInfoSpecOutput((part as { output?: unknown }).output)
+  })
+}
+
+function accountRenderFromFinishArg(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false
+  if ('parts' in value) return partsHaveAccountRender(value.parts)
+  if ('message' in value && value.message && typeof value.message === 'object')
+    return accountRenderFromFinishArg(value.message)
+  return false
+}
+
 export interface AssistantChatProps {
   className?: string
   header?: ReactNode
@@ -45,9 +68,31 @@ export interface AssistantChatProps {
 
 export function AssistantChat({ className, header, hideHeader }: AssistantChatProps) {
   const [input, setInput] = useState('')
-  const { messages, status, sendMessage, stop, error, clearError } = useChatFromConfig()
+  const turnCaptured = useRef(false)
+  const pendingOutcome = useRef<'stopped' | null>(null)
+  const { messages, status, sendMessage, stop, error, clearError } = useChatFromConfig({
+    onFinish: (...args: unknown[]) => {
+      const accountRender = args.some(accountRenderFromFinishArg)
+      const outcome = pendingOutcome.current ?? 'completed'
+      pendingOutcome.current = null
+      if (turnCaptured.current) return
+      turnCaptured.current = true
+      capture({ name: 'assistant_turn', outcome, accountRender })
+    },
+    onError: () => {
+      pendingOutcome.current = null
+      if (turnCaptured.current) return
+      turnCaptured.current = true
+      capture({ name: 'assistant_turn', outcome: 'error', accountRender: false })
+    },
+  })
   const conversationRef = useRef<HTMLDivElement>(null)
   const lastUserMessageRef = useRef<HTMLDivElement>(null)
+
+  const beginTurn = () => {
+    turnCaptured.current = false
+    pendingOutcome.current = null
+  }
 
   useEffect(() => {
     const last = messages.at(-1)
@@ -67,12 +112,27 @@ export function AssistantChat({ className, header, hideHeader }: AssistantChatPr
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
     if (!input.trim()) return
+    beginTurn()
     sendMessage({ text: input })
     setInput('')
   }
 
   const handleSuggestion = (text: string) => {
+    beginTurn()
     sendMessage({ text })
+  }
+
+  const handleStop = () => {
+    pendingOutcome.current = 'stopped'
+    const lastAssistant = [...messages].reverse().find(m => m.role === 'assistant')
+    stop()
+    if (turnCaptured.current) return
+    turnCaptured.current = true
+    capture({
+      name: 'assistant_turn',
+      outcome: 'stopped',
+      accountRender: partsHaveAccountRender(lastAssistant?.parts),
+    })
   }
 
   const lastAssistantMessage = [...messages].reverse().find(m => m.role === 'assistant')
@@ -228,7 +288,7 @@ export function AssistantChat({ className, header, hideHeader }: AssistantChatPr
             <PromptInputSubmit
               status={status}
               disabled={!input.trim() && status !== 'streaming'}
-              onStop={stop}
+              onStop={handleStop}
             />
           </div>
         </Input>

--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -1,0 +1,22 @@
+/** Same literals as `signInMethod` on sessions. Do not widen to `string`. */
+export type SignInMethod =
+  | 'magic_link'
+  | 'oauth_google'
+  | 'oauth_github'
+  | 'oauth_facebook'
+  | 'oauth_twitter'
+  | 'passkey'
+  | 'web3_eip155'
+  | 'web3_solana'
+
+export type ProductEvent =
+  | { name: 'auth_succeeded'; method: SignInMethod }
+  | { name: 'auth_failed'; method: SignInMethod; errorCode: string }
+  | {
+      name: 'assistant_turn'
+      outcome: 'completed' | 'stopped' | 'error'
+      accountRender: boolean
+    }
+
+/** Instrumented, not collected — no analytics sink. */
+export function capture(_event: ProductEvent): void {}

--- a/apps/web/lib/analytics.types.test.ts
+++ b/apps/web/lib/analytics.types.test.ts
@@ -1,0 +1,15 @@
+import { capture } from './analytics'
+
+// Valid combinations compile.
+capture({ name: 'auth_succeeded', method: 'magic_link' })
+capture({ name: 'auth_failed', method: 'oauth_google', errorCode: 'oauth_failed_google' })
+capture({ name: 'assistant_turn', outcome: 'completed', accountRender: true })
+
+// @ts-expect-error invalid property on auth_succeeded
+capture({ name: 'auth_succeeded', method: 'magic_link', errorCode: 'x' })
+
+// @ts-expect-error unknown event name
+capture({ name: 'auth_method_selected', method: 'magic_link' })
+
+// @ts-expect-error assistant props on auth event
+capture({ name: 'auth_failed', method: 'passkey', errorCode: 'x', accountRender: true })

--- a/apps/web/lib/auth/callback-utils.ts
+++ b/apps/web/lib/auth/callback-utils.ts
@@ -1,6 +1,7 @@
 import { ApiError } from '@repo/core'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
+import { capture, type SignInMethod } from '@/lib/analytics'
 import { env } from '@/lib/env'
 import { authCookieSchema } from './auth-schemas'
 import { setAuthCookiesOnResponse } from './auth-server'
@@ -27,23 +28,28 @@ export function completeOAuthCallback({
   request,
   response,
   failureMessage,
+  method,
 }: {
   request: Request
   response: unknown
   failureMessage: string
+  method: SignInMethod
 }): NextResponse {
   const tokens = extractTokens(response)
-  if (!tokens)
+  if (!tokens) {
+    capture({ name: 'auth_failed', method, errorCode: failureMessage })
     return NextResponse.redirect(
       new URL(`/auth/login?message=${encodeURIComponent(failureMessage)}`, request.url),
       303,
     )
+  }
 
   const redirectResponse = NextResponse.redirect(
     new URL(getOAuthRedirectTarget(response), request.url),
     303,
   )
   setAuthCookiesOnResponse(redirectResponse, tokens)
+  capture({ name: 'auth_succeeded', method })
   return redirectResponse
 }
 
@@ -56,7 +62,7 @@ export async function handleOAuthBffGet({
   mapError,
 }: {
   request: Request
-  method: string
+  method: SignInMethod
   failureMessage: string
   fallbackMessage: string
   exchange: (args: { client: BffClient; code: string; state: string }) => Promise<unknown>
@@ -65,11 +71,13 @@ export async function handleOAuthBffGet({
   const { searchParams } = new URL(request.url)
   const code = searchParams.get('code')
   const state = searchParams.get('state')
-  if (!code || !state)
+  if (!code || !state) {
+    capture({ name: 'auth_failed', method, errorCode: 'missing_params' })
     return NextResponse.redirect(
       new URL(`/auth/login?message=${encodeURIComponent('missing_params')}`, request.url),
       303,
     )
+  }
 
   const cookieStore = await cookies()
   const { token } = parseAuthCookie(cookieStore.get(env.NEXT_PUBLIC_AUTH_COOKIE_NAME)?.value)
@@ -77,12 +85,13 @@ export async function handleOAuthBffGet({
 
   try {
     const response = await exchange({ client, code, state })
-    return completeOAuthCallback({ request, response, failureMessage })
+    return completeOAuthCallback({ request, response, failureMessage, method })
   } catch (error) {
     logAuthBffFailure({ error, reqId, method })
     const rawMessage = error instanceof Error ? error.message : fallbackMessage
     const body = error instanceof ApiError ? error.body : undefined
     const errorCode = mapError(rawMessage, body)
+    capture({ name: 'auth_failed', method, errorCode })
     return NextResponse.redirect(
       new URL(`/auth/login?message=${encodeURIComponent(errorCode)}`, request.url),
       303,


### PR DESCRIPTION
## Summary
- Add `apps/web/lib/analytics.ts` `capture()` as a discriminated union (`auth_succeeded`, `auth_failed`, `assistant_turn`) with no sink. Auth and assistant are specified and instrumented, not collected. PostHog stays uninstalled (ADR 011).
- Fire auth events only at login cookie/token set and catalog-coded failures (OAuth, magic link, passkey, One Tap, web3 success). Do not wrap refresh, proxy rotation, change-email, or `update-tokens`.
- Emit one `assistant_turn` per submitted chat turn (`onFinish` / `onError` / stop). Account-context completion is `completed` and `accountRender: true` (`__render: 'user-info'`).
- Update FIRST overlays, architecture MDX (analytics, AI, logging), ADR 011, and `apps/web/README.md`. Privacy copy unchanged.

## Test plan
- [x] `pnpm qa` (checktypes, lint, OpenAPI drift, build, unit tests, e2e)
- [ ] Confirm login success still reaches `/` (magic link / OAuth) and failed callbacks still show catalog messages
- [ ] Confirm token refresh / `POST /api/auth/update-tokens` / change-email do not go through login `capture()` paths
- [ ] Confirm assistant “Who am I?” still streams; stop/error does not break chat UI