### PR TITLE
docs(docu): add product roadmap and issue backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Run with `pnpm <script>`.
 
 Full docs: [basilic-docs.vercel.app](https://basilic-docs.vercel.app/docs)
 
-- [Product](https://basilic-docs.vercel.app/docs/product) — what Basilic is, feature map, non-goals
+- [Product](https://basilic-docs.vercel.app/docs/product) — what Basilic is, feature map, roadmap
 - [Getting Started](https://basilic-docs.vercel.app/docs/development) — clone, `pnpm setup`, `db:start`, `pnpm reset`, `pnpm dev`
 - [Product Ready](https://basilic-docs.vercel.app/docs/testing/product-ready) — fork-and-run bar (not CI green)
 - [Dev Environments](https://basilic-docs.vercel.app/docs/development/dev-environments) — Local vs remote (ports 3000, 3001, 8081; `start:localhost`, `start:tunnel`)

--- a/_first/basilic/DOCUMENTATION.md
+++ b/_first/basilic/DOCUMENTATION.md
@@ -21,6 +21,7 @@ Consequential decisions, conventions, setup steps, and domain context live in di
 - **Fact:** Public LLM indexes: `/llms.txt`, `/llms-full.txt` on the docs site
 - **Fact:** Portable factory: vendored `../AGENTS.md`, `../ABOUT.md`, `../principles/`. This folder is the Basilic adoption pack, not a second docs site. Essays live in [`blockmatic/first`](https://github.com/blockmatic/first/tree/main/_first/articles).
 - **Fact:** Same-change rule: update matching MDX when behavior, commands, or conventions change
+- **Fact:** `__dev/` is gitignored scratch. Do not treat it as Fact or as the backlog. Remembered decisions go in `apps/docu` or ADRs.
 - **Drift:** named in sibling instances (PostHog, “API as source of truth”, portability vs Vercel). Fix MDX in the same work when you change the fact; do not leave load-bearing drift only in chat.
 
 ## Minimum Useful Artifact

--- a/_first/basilic/PIPELINES.md
+++ b/_first/basilic/PIPELINES.md
@@ -22,6 +22,7 @@ Changes flow through an automated path: format → lint → typecheck → test �
 - **Fact:** Local: `pnpm qa` via [`../../scripts/run-qa.mjs`](../../scripts/run-qa.mjs) — checktypes → lint → generate + drift → build → unit → e2e (`SKIP_BUILD=1`)
 - **Fact:** Vercel git deploys web/api/docu ([vercel.mdx](../../apps/docu/content/docs/deployment/vercel.mdx)). CI does **not** deploy. Preview migrate gated unless `RUN_PG_MIGRATE=true`.
 - **Fact:** `web-e2e` needs `ANTHROPIC_API_KEY`
+- **Fact:** R0 is documentation alignment. It does not require a GitHub Release or a version bump. Preview deploys still run from git as usual.
 - **Unresolved:** commit-stage artifact identity and promote-without-rebuild (hosts rebuild from git)
 
 ## Minimum Useful Artifact

--- a/_first/basilic/PRODUCT.md
+++ b/_first/basilic/PRODUCT.md
@@ -14,7 +14,7 @@ The project has an inspectable answer to what, why, and how we will know. Non-go
 
 ## Artifacts
 
-- **Fact:** Canonical product brief: [product/index.mdx](../../apps/docu/content/docs/product/index.mdx) and [product/features.mdx](../../apps/docu/content/docs/product/features.mdx)
+- **Fact:** Canonical product brief: [product/index.mdx](../../apps/docu/content/docs/product/index.mdx), [product/features.mdx](../../apps/docu/content/docs/product/features.mdx), [product/roadmap.mdx](../../apps/docu/content/docs/product/roadmap.mdx)
 - **Fact:** [`../../README.md`](../../README.md) — fork-and-run TypeScript fullstack starter (Fastify, OpenAPI, Next, Expo scaffold). No Wagmi, no first-class OpenAI SDK, no web wallet UI
 - **Fact:** [`../../apps/docu/content/docs/index.mdx`](../../apps/docu/content/docs/index.mdx) — toolkit intro; Product is in the docs nav
 - **Fact:** Two audiences: **adopters** (developers using the starter) and **demo users** (web news `/`, markets, settings, in-shell assistant; auth is the shipped job)
@@ -28,7 +28,7 @@ The project has an inspectable answer to what, why, and how we will know. Non-go
 - **Fact:** PD (Markets + GenAI artifacts) is named on the feature map as **intended**, not shipped
 - **Unresolved:** PostHog install / consent / retention; keep / iterate / kill board; whether adopters copy `lib/analytics`
 
-`pnpm qa` going green is Quality/Pipelines, not product success.
+`pnpm qa` going green is Pipelines, not product success. Quality for R0 is [Product Ready](../../apps/docu/content/docs/testing/product-ready.mdx).
 
 ## Minimum Useful Artifact
 

--- a/_first/basilic/WORKFLOW.md
+++ b/_first/basilic/WORKFLOW.md
@@ -14,10 +14,10 @@ Work flows through a recognizable path: idea → plan → implement → review �
 
 ## Artifacts
 
-- **Fact:** Path: plan (`/plan-feature`) → review → implement (`/exec-push`) → `/git-commit` → PR → CI + CodeRabbit → `/retro`
+- **Fact:** Work state: GitHub Issues and pull requests. There is no `BACKLOG.md`. `__dev/` is gitignored scratch, not the backlog.
+- **Fact:** Path: plan (`/plan-feature`) → review → implement → `/git-commit` → `/git-create-pr` → CI + CodeRabbit → `/retro`. Prefer `/git-create-pr` (description + labels) over `/exec-push`.
 - **Fact:** Index: [ai-workflow.mdx](../../apps/docu/content/docs/development/ai-workflow.mdx)
 - **Fact:** Playbooks: `.agents/skills/workflow/` — `plan-feature`, `exec-push`, `git-commit`, `code-review`, `deslop`, `retro`, `git-create-pr`
-- **Fact:** Work state: GitHub issues and pull requests
 - **Fact:** Consequential decisions: ADRs and `apps/docu`
 - **Fact:** Git: default global user; Conventional Commits; never `--no-verify`; never Co-authored-by trailers ([git.mdc](../../.cursor/rules/base/git.mdc))
 - **Fact:** Human gates: product scope, secrets/trust boundaries, destructive ops ([`../AGENTS.md`](../AGENTS.md))
@@ -29,7 +29,7 @@ Work flows through a recognizable path: idea → plan → implement → review �
 - plan and acceptance criteria: `/plan-feature` for non-trivial work
 - actors: human, agent, CI, CodeRabbit
 - gates: product, security, destructive — ask a human
-- validation: CI; learning: `/retro` and durable files when decisions changed
+- validation: Product Ready for adopter bar; CI for Pipelines; learning: `/retro` and durable files when decisions changed
 
 ## Recipe
 
@@ -59,7 +59,7 @@ Apply Workflow First to Basilic.
 
 Read current issues/PRs, ai-workflow MDX, and `.agents/skills/workflow/` before acting. Do not rely on chat as the system of record.
 
-Propose before implementing on non-trivial work. Implement in reviewable chunks. Use `/exec-push` and `/git-commit`. Never `--no-verify`. Use the default global git user.
+Propose before implementing on non-trivial work. Implement in reviewable chunks. Use `/git-commit` and `/git-create-pr`. Never `--no-verify`. Use the default global git user.
 
 Stop and ask a human for product scope, security-sensitive changes, and destructive operations. Update issues, PRs, and documentation as work progresses. Preserve intentional existing process.
 

--- a/apps/docu/content/docs/index.mdx
+++ b/apps/docu/content/docs/index.mdx
@@ -15,7 +15,7 @@ LLM-friendly index: [`/llms.txt`](/llms.txt) (table of contents) and [`/llms-ful
       <h3 className="text-lg font-semibold">Product</h3>
     </div>
     <p className="text-sm text-muted-foreground">
-      Starter vs demo, feature map, goals and non-goals.
+      Starter vs demo, feature map, goals, and roadmap.
     </p>
     <div className="mt-4">
       <a href="/docs/product" className="text-sm font-medium text-primary hover:underline">

--- a/apps/docu/content/docs/product/features.mdx
+++ b/apps/docu/content/docs/product/features.mdx
@@ -3,7 +3,7 @@ title: Feature map
 description: Shipped spine, demo chrome, packages without web UX, inactive scaffolds, R0 non-goals, and the PD demo bet.
 ---
 
-Status is what the tree does today, not a wish list. Roadmap horizons live in a later Product page.
+Status is what the tree does today, not a wish list. Horizons: [Roadmap](/docs/product/roadmap).
 
 ## Spine (fork-and-run)
 

--- a/apps/docu/content/docs/product/index.mdx
+++ b/apps/docu/content/docs/product/index.mdx
@@ -30,7 +30,7 @@ A portable typed API plus web, mobile scaffold, and docs so an adopting develope
 
 ## How we will know
 
-`pnpm qa` going green is Quality and Pipelines, not product success.
+`pnpm qa` going green is **Pipelines**, not product success. The R0 Quality bar is [Product Ready](/docs/testing/product-ready). Horizons: [Roadmap](/docs/product/roadmap).
 
 Auth (`auth_succeeded` / `auth_failed`) and assistant (`assistant_turn` with `accountRender`) are **instrumented** via `capture()` and **not collected** — PostHog is chosen, not installed. Those jobs are therefore **unmeasured**. Factory GTM, demo surface quality, and cost-per-job are unmeasured.
 
@@ -39,6 +39,7 @@ Finance: **N/A** (toolkit).
 ## Related
 
 - [Feature map](/docs/product/features)
+- [Roadmap](/docs/product/roadmap)
 - [Authentication](/docs/architecture/authentication)
 - [Frontend](/docs/architecture/frontend) — no wallet UI
 - [Product analytics](/docs/architecture/analytics)

--- a/apps/docu/content/docs/product/meta.json
+++ b/apps/docu/content/docs/product/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Product",
-  "pages": ["index", "features"]
+  "pages": ["index", "features", "roadmap"]
 }

--- a/apps/docu/content/docs/product/roadmap.mdx
+++ b/apps/docu/content/docs/product/roadmap.mdx
@@ -1,0 +1,39 @@
+---
+title: Roadmap
+description: R0, R-demo, later bets, and not-now. Backlog is GitHub Issues, not a markdown file.
+---
+
+Horizons, not a sprint board. Work items live in [GitHub Issues](https://github.com/blockmatic/basilic/issues). `__dev/` is gitignored scratch — not Fact, not the backlog.
+
+R0 is **documentation alignment**. It does not need a semver bump or a GitHub Release. Pipelines still run on PRs; Quality is [Product Ready](/docs/testing/product-ready).
+
+## R0 — docs, honesty, onboarding
+
+- Product pages: what Basilic is, [feature map](/docs/product/features), this roadmap
+- Honesty in README and auth docs (starter, not wallet/OpenAI template)
+- [Product Ready](/docs/testing/product-ready): `db:start` + `pnpm reset` before `pnpm dev`
+
+## R-demo — Markets + GenAI artifacts
+
+Named even if the implementation PR is still in flight: CoinGecko or checked-in mock, `getMarketSnapshot` + market-card catalog, Markets as signed-in home. No wallet UI. No Fastify markets CRUD. No extra CI workflow. See [Features](/docs/product/features).
+
+## Later (ask before R0)
+
+Tracked as issues. Do not treat them as committed R1.
+
+- PostHog install — [#183](https://github.com/blockmatic/basilic/issues/183)
+- Turn Sentry on — [#184](https://github.com/blockmatic/basilic/issues/184)
+- Wallet connect UI — [#185](https://github.com/blockmatic/basilic/issues/185)
+- Mobile `@repo/core` client — [#186](https://github.com/blockmatic/basilic/issues/186)
+
+R1 is still a choice among wallet UI, mobile client, and observability — not all three.
+
+## Not now
+
+FIRST CLI, `first.json`, FIRST as a Cursor skill, billed SaaS / TAM-LTV, first-class OpenAI SDK, GCP/AWS as the shipped deploy path, Cache Components on, 13th FIRST station, root `PRODUCT.md` / `ROADMAP.md`.
+
+## Related
+
+- [Product](/docs/product)
+- [Feature map](/docs/product/features)
+- [Product Ready](/docs/testing/product-ready)


### PR DESCRIPTION
## Summary
- Adds `apps/docu/content/docs/product/roadmap.mdx`: R0 (docs/honesty/onboarding), R-demo (Markets + GenAI, even if PD is in flight), later bets, not-now.
- Backlog is GitHub Issues (not `BACKLOG.md`). `__dev/` is scratch. R0 does not need a GitHub Release.
- Later-bet issues: #183 PostHog, #184 Sentry, #185 wallet UI, #186 mobile client.

## Test plan
- [ ] Product nav shows Roadmap
- [ ] Issues #183–#186 exist and match the later-bets list
- [ ] WORKFLOW overlay does not send agents to `__dev/` as SoR