### PR TITLE
chore: vendor FIRST overlay-as-delta user pack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,6 @@ This repository uses **Cursor-native** AI workflows. Do not run a parallel proce
 - `.cursor/rules/` — constraints (override skills)
 - `.agents/skills/` — tech patterns (`<topic>-v<major>/`) and slash playbooks under `workflow/`; install/refresh via `pnpm dlx skills@latest add blockmatic/basilic-skills` (see [Cursor Skills](apps/docu/content/docs/development/cursor-skills.mdx)). Catalog: [`blockmatic/basilic-skills`](https://github.com/blockmatic/basilic-skills)
 - `apps/docu/content/docs/` — architecture, ADRs, how-to
-- FIRST: `_first/AGENTS.md` then `_first/FIRST.md`; then `_first/principles/X.md` and the instance path listed in FIRST.md. Factory source: [`blockmatic/first`](https://github.com/blockmatic/first).
+- FIRST: `_first/AGENTS.md` then `_first/ABOUT.md` then `_first/FIRST.md`; then `_first/principles/X.md` and the instance path listed in FIRST.md. Factory source: [`blockmatic/first`](https://github.com/blockmatic/first).
 
 Details: `apps/docu/content/docs/development/ai-workflow.mdx`.

--- a/_first/ABOUT.md
+++ b/_first/ABOUT.md
@@ -1,7 +1,7 @@
 # First Principles
 
 Version: 0.2-draft  
-Last reviewed: 2026-09-03
+Last reviewed: 2026-09-04
 
 Some decisions are too consequential to become afterthoughts. Important project knowledge should live in files, not disappear into conversations.
 
@@ -13,6 +13,13 @@ This is an agent-first factory, not an agent-autonomous one. Humans still decide
 
 - **Users of the framework** — adopting FIRST in a product repo. Copy the user pack into `_first/`. Edit [FIRST.md](FIRST.md) and opted-in station files. Merge a pointer into root `AGENTS.md`.
 - **Maintainers of the framework** — evolving FIRST itself. Start at [`blockmatic/first` maintainers](https://github.com/blockmatic/first/blob/main/_first/maintainers/README.md). Do not copy `maintainers/` or `instance/`.
+
+## Dual audience (minimum)
+
+- **User of the framework:** copy the user pack, write `FIRST.md`, keep product facts in instance files or docs those files point at.
+- **Maintainer of the framework:** edit `principles/`, `articles/`, `maintainers/`, and `packages/validate`. Do not encode one adopter’s product into generic files.
+
+Each principle’s **Definition of Done** is that station’s artifact. It is not the whole factory, not CI green, and not Product success after use. Quality / Product / Pipelines qualify “done” differently — see Boundaries below.
 
 ## Audiences
 

--- a/_first/basilic/README.md
+++ b/_first/basilic/README.md
@@ -63,3 +63,8 @@ From a station file in this folder:
 | 12 | Operations | [OPERATIONS.md](OPERATIONS.md) |
 
 Do not invent TAM, event taxonomies, or SLOs to complete a template. Label **Fact**, **Drift**, and **Unresolved** under Artifacts.
+
+## Overlay as delta
+
+Keep the required `##` headings. Fill Artifacts with pointers and facts. Do **not** paste the generic Recipe, Agent Prompt, or Statement from `../principles/X.md`. Canonical briefs live in `apps/docu`. `__dev/` is scratch until it graduates into docs or this overlay.
+

--- a/_first/principles/DOCUMENTATION.md
+++ b/_first/principles/DOCUMENTATION.md
@@ -54,7 +54,9 @@ Public documentation may include `llms.txt` as a selective, machine-readable ori
 
 ## Definition of Done
 
-Durable context is written, accurate, and discoverable. Documentation drift is resolved or explicitly tracked. Future work will not need to rediscover what was already decided.
+This station’s durable context is written, accurate, and discoverable. Documentation drift is resolved or explicitly tracked. Future work will not need to rediscover what was already decided. This is not “CI is green.”
+
+Scratch (`__dev/` or chat) **graduates** when a decision must survive a new session: write it into the canonical doc (or an ADR) in the same change. Do not leave load-bearing Fact only in gitignored scratch.
 
 ## Agent Prompt
 

--- a/_first/principles/PRODUCT.md
+++ b/_first/principles/PRODUCT.md
@@ -31,14 +31,16 @@ When the product is a business, also:
 - Runway / burn / time to breakeven when the product is the company
 - AARRR as a prompt for acquisition through revenue, not a mandatory scorecard
 
+When the product is a **toolkit or starter** (fork-and-run, not a billed SaaS), skip TAM, LTV, CAC, and AARRR. Write **N/A (toolkit)** once. Do not invent a marketplace to complete the template.
+
 Do not invent TAM, LTV, or a fog of events to complete a template. An internal tool may have none of the finance fields. Then say so.
 
 ## Minimum Useful Artifact
 
-- problem, users, and business or organizational goal
+- problem, users, and business or organizational goal (toolkit: goal is first successful clone, not revenue)
 - requirements, constraints, and explicit non-goals
 - audience, channel, and first successful use
-- one to three metrics with definition, target, and timeframe
+- one to three metrics with definition, target, and timeframe — or **unmeasured** / **N/A (toolkit)**
 - events that make each metric observable, or `unmeasured`
 - assumptions, open questions, and named decision owners
 
@@ -63,7 +65,7 @@ Do not invent TAM, LTV, or a fog of events to complete a template. An internal t
 
 ## Definition of Done
 
-Product intent is documented or explicitly deferred with named owners. Implementation aligns with stated goals and non-goals, or the docs were updated. Success that was claimed is either instrumented or marked unmeasured.
+This station’s product artifact is documented or explicitly deferred with named owners. Implementation aligns with stated goals and non-goals, or the docs were updated. Success that was claimed is either instrumented or marked unmeasured. This is not “the whole repository is done.”
 
 ## Agent Prompt
 

--- a/_first/principles/QUALITY.md
+++ b/_first/principles/QUALITY.md
@@ -52,7 +52,7 @@ Choose the mechanism that matches the output. Deterministic code gets tests. Mod
 
 ## Definition of Done
 
-Stated quality criteria are met and verified by the project's existing validation. Regressions are caught or explicitly accepted with documented rationale.
+This station’s stated quality criteria are met and verified by the project's existing validation. Regressions are caught or explicitly accepted with documented rationale. CI going green is Pipelines. This is not Product success after use.
 
 ## Agent Prompt
 


### PR DESCRIPTION
## Summary
- Replaces `_first/AGENTS.md` (unchanged), `_first/ABOUT.md`, and `principles/{PRODUCT,QUALITY,DOCUMENTATION}` from [blockmatic/first#1](https://github.com/blockmatic/first/pull/1).
- Does **not** overwrite `_first/FIRST.md` or station overlays except README overlay-as-delta note.
- Root `AGENTS.md` load order now includes `_first/ABOUT.md`.

## Test plan
- [ ] Diff contains no `FIRST.md` or overlay station files besides `basilic/README.md`
- [ ] Principles match first PR after review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to include the `_first/ABOUT.md` document in the required reading order.
  * Clarified the framework’s dual audiences and station-specific completion criteria.
  * Added guidance for maintaining station overlays and separating canonical documentation from scratch content.
  * Clarified when scratch decisions must be recorded in canonical documentation or an ADR.
  * Updated product guidance for toolkit projects, including applicable metrics and first-clone success criteria.
  * Clarified that quality and product completion are evaluated independently from CI status and repository-wide completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->