### PR TITLE
docs: fix skills path and FIRST article pointers

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -5,14 +5,15 @@ Rules, skills, and MCP for AI-assisted development. Daily workflow: [AI Developm
 ## Layout
 
 - [`rules/`](rules/) — constraints. Glob-scoped except `base/general.mdc`, `base/naming.mdc`, `base/git.mdc`, `base/file-organization.mdc` (always on).
-- [`skills/`](skills/) — on-demand expertise (`<topic>-v<major>/`) and slash playbooks under `workflow/`. Refresh: `pnpm dlx skills@latest add blockmatic/basilic-skills` ([Cursor Skills](../apps/docu/content/docs/development/cursor-skills.mdx)). Catalog: [blockmatic/basilic-skills](https://github.com/blockmatic/basilic-skills).
+- [`.agents/skills/`](../.agents/skills/) — on-demand expertise (`<topic>-v<major>/`) and slash playbooks under `workflow/`. Refresh: `pnpm dlx skills@latest add blockmatic/basilic-skills` ([Cursor Skills](../apps/docu/content/docs/development/cursor-skills.mdx)). Catalog: [blockmatic/basilic-skills](https://github.com/blockmatic/basilic-skills). There is no `.cursor/skills/` tree in this repo.
 - [`mcp.json`](mcp.json) — MCP servers. Setup: [Cursor Setup](../apps/docu/content/docs/development/cursor-setup.mdx).
 
-Type `/` in chat for playbooks (`/plan-feature`, `/exec-push`, `/git-commit`, `/retro`). Tech skills load when relevant, or `@.agents/skills/<name>`.
+Type `/` in chat for playbooks (`/plan-feature`, `/git-create-pr`, `/git-commit`, `/retro`). Tech skills load when relevant, or `@.agents/skills/<name>`.
 
 ## Related
 
 - [AI Workflow](https://basilic-docs.vercel.app/docs/development/ai-workflow)
+- FIRST: [`_first/README.md`](../_first/README.md) — load `_first/AGENTS.md` then `_first/ABOUT.md` then `_first/FIRST.md`
 - [Cursor Setup](https://basilic-docs.vercel.app/docs/development/cursor-setup)
 - [Cursor Skills](https://basilic-docs.vercel.app/docs/development/cursor-skills)
 - [Cursor rules](https://cursor.com/docs/context/rules) · [skills](https://cursor.com/docs/context/skills)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,6 @@ This repository uses **Cursor-native** AI workflows. Do not run a parallel proce
 - `.cursor/rules/` — constraints (override skills)
 - `.agents/skills/` — tech patterns (`<topic>-v<major>/`) and slash playbooks under `workflow/`; install/refresh via `pnpm dlx skills@latest add blockmatic/basilic-skills` (see [Cursor Skills](apps/docu/content/docs/development/cursor-skills.mdx)). Catalog: [`blockmatic/basilic-skills`](https://github.com/blockmatic/basilic-skills)
 - `apps/docu/content/docs/` — architecture, ADRs, how-to
-- FIRST: `_first/AGENTS.md` then `_first/FIRST.md`; then `_first/principles/X.md` and the instance path listed in FIRST.md. Factory source: [`blockmatic/first`](https://github.com/blockmatic/first).
+- FIRST: `_first/AGENTS.md` then `_first/ABOUT.md` then `_first/FIRST.md`; then `_first/principles/X.md` and the instance path listed in FIRST.md. Factory source: [`blockmatic/first`](https://github.com/blockmatic/first).
 
 Details: `apps/docu/content/docs/development/ai-workflow.mdx`.

--- a/_first/ABOUT.md
+++ b/_first/ABOUT.md
@@ -1,7 +1,7 @@
 # First Principles
 
 Version: 0.2-draft  
-Last reviewed: 2026-09-03
+Last reviewed: 2026-09-04
 
 Some decisions are too consequential to become afterthoughts. Important project knowledge should live in files, not disappear into conversations.
 
@@ -13,6 +13,13 @@ This is an agent-first factory, not an agent-autonomous one. Humans still decide
 
 - **Users of the framework** — adopting FIRST in a product repo. Copy the user pack into `_first/`. Edit [FIRST.md](FIRST.md) and opted-in station files. Merge a pointer into root `AGENTS.md`.
 - **Maintainers of the framework** — evolving FIRST itself. Start at [`blockmatic/first` maintainers](https://github.com/blockmatic/first/blob/main/_first/maintainers/README.md). Do not copy `maintainers/` or `instance/`.
+
+## Dual audience (minimum)
+
+- **User of the framework:** copy the user pack, write `FIRST.md`, keep product facts in instance files or docs those files point at.
+- **Maintainer of the framework:** edit `principles/`, `articles/`, `maintainers/`, and `packages/validate`. Do not encode one adopter’s product into generic files.
+
+Each principle’s **Definition of Done** is that station’s artifact. It is not the whole factory, not CI green, and not Product success after use. Quality / Product / Pipelines qualify “done” differently — see Boundaries below.
 
 ## Audiences
 

--- a/_first/README.md
+++ b/_first/README.md
@@ -23,7 +23,7 @@ cp ../first/_first/ABOUT.md _first/ABOUT.md
 rsync -a --delete ../first/_first/principles/ _first/principles/
 ```
 
-Or copy those paths from a tagged `first` release. Skip `instance/` and `maintainers/`. Essays are optional; this repo links to them on the FIRST site instead of vendoring `articles/`.
+Or copy those paths from a tagged `first` release. Skip `instance/` and `maintainers/`. Essays are not fully vendored: `_first/articles/` holds pointer stubs so principle Navigation links resolve. The arguments live on [GitHub](https://github.com/blockmatic/first/tree/main/_first/articles).
 
 ## Human door
 

--- a/_first/articles/API.md
+++ b/_first/articles/API.md
@@ -1,0 +1,5 @@
+# API
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/API.md
+
+Do not treat this stub as the argument. It exists so `principles/API.md` local links resolve.

--- a/_first/articles/ARCHITECTURE.md
+++ b/_first/articles/ARCHITECTURE.md
@@ -1,0 +1,5 @@
+# ARCHITECTURE
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/ARCHITECTURE.md
+
+Do not treat this stub as the argument. It exists so `principles/ARCHITECTURE.md` local links resolve.

--- a/_first/articles/DATA.md
+++ b/_first/articles/DATA.md
@@ -1,0 +1,5 @@
+# DATA
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/DATA.md
+
+Do not treat this stub as the argument. It exists so `principles/DATA.md` local links resolve.

--- a/_first/articles/DESIGN.md
+++ b/_first/articles/DESIGN.md
@@ -1,0 +1,5 @@
+# DESIGN
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/DESIGN.md
+
+Do not treat this stub as the argument. It exists so `principles/DESIGN.md` local links resolve.

--- a/_first/articles/DOCUMENTATION.md
+++ b/_first/articles/DOCUMENTATION.md
@@ -1,0 +1,5 @@
+# DOCUMENTATION
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/DOCUMENTATION.md
+
+Do not treat this stub as the argument. It exists so `principles/DOCUMENTATION.md` local links resolve.

--- a/_first/articles/JOURNEYS.md
+++ b/_first/articles/JOURNEYS.md
@@ -1,0 +1,5 @@
+# JOURNEYS
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/JOURNEYS.md
+
+Do not treat this stub as the argument. It exists so `principles/JOURNEYS.md` local links resolve.

--- a/_first/articles/OPERATIONS.md
+++ b/_first/articles/OPERATIONS.md
@@ -1,0 +1,5 @@
+# OPERATIONS
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/OPERATIONS.md
+
+Do not treat this stub as the argument. It exists so `principles/OPERATIONS.md` local links resolve.

--- a/_first/articles/PIPELINES.md
+++ b/_first/articles/PIPELINES.md
@@ -1,0 +1,5 @@
+# PIPELINES
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/PIPELINES.md
+
+Do not treat this stub as the argument. It exists so `principles/PIPELINES.md` local links resolve.

--- a/_first/articles/PRODUCT.md
+++ b/_first/articles/PRODUCT.md
@@ -1,0 +1,5 @@
+# PRODUCT
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/PRODUCT.md
+
+Do not treat this stub as the argument. It exists so `principles/PRODUCT.md` local links resolve.

--- a/_first/articles/QUALITY.md
+++ b/_first/articles/QUALITY.md
@@ -1,0 +1,5 @@
+# QUALITY
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/QUALITY.md
+
+Do not treat this stub as the argument. It exists so `principles/QUALITY.md` local links resolve.

--- a/_first/articles/SECURITY.md
+++ b/_first/articles/SECURITY.md
@@ -1,0 +1,5 @@
+# SECURITY
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/SECURITY.md
+
+Do not treat this stub as the argument. It exists so `principles/SECURITY.md` local links resolve.

--- a/_first/articles/WORKFLOW.md
+++ b/_first/articles/WORKFLOW.md
@@ -1,0 +1,5 @@
+# WORKFLOW
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/WORKFLOW.md
+
+Do not treat this stub as the argument. It exists so `principles/WORKFLOW.md` local links resolve.

--- a/_first/basilic/README.md
+++ b/_first/basilic/README.md
@@ -63,3 +63,8 @@ From a station file in this folder:
 | 12 | Operations | [OPERATIONS.md](OPERATIONS.md) |
 
 Do not invent TAM, event taxonomies, or SLOs to complete a template. Label **Fact**, **Drift**, and **Unresolved** under Artifacts.
+
+## Overlay as delta
+
+Keep the required `##` headings. Fill Artifacts with pointers and facts. Do **not** paste the generic Recipe, Agent Prompt, or Statement from `../principles/X.md`. Canonical briefs live in `apps/docu`. `__dev/` is scratch until it graduates into docs or this overlay.
+

--- a/_first/principles/DOCUMENTATION.md
+++ b/_first/principles/DOCUMENTATION.md
@@ -54,7 +54,9 @@ Public documentation may include `llms.txt` as a selective, machine-readable ori
 
 ## Definition of Done
 
-Durable context is written, accurate, and discoverable. Documentation drift is resolved or explicitly tracked. Future work will not need to rediscover what was already decided.
+This station’s durable context is written, accurate, and discoverable. Documentation drift is resolved or explicitly tracked. Future work will not need to rediscover what was already decided. This is not “CI is green.”
+
+Scratch (`__dev/` or chat) **graduates** when a decision must survive a new session: write it into the canonical doc (or an ADR) in the same change. Do not leave load-bearing Fact only in gitignored scratch.
 
 ## Agent Prompt
 

--- a/_first/principles/PRODUCT.md
+++ b/_first/principles/PRODUCT.md
@@ -31,14 +31,16 @@ When the product is a business, also:
 - Runway / burn / time to breakeven when the product is the company
 - AARRR as a prompt for acquisition through revenue, not a mandatory scorecard
 
+When the product is a **toolkit or starter** (fork-and-run, not a billed SaaS), skip TAM, LTV, CAC, and AARRR. Write **N/A (toolkit)** once. Do not invent a marketplace to complete the template.
+
 Do not invent TAM, LTV, or a fog of events to complete a template. An internal tool may have none of the finance fields. Then say so.
 
 ## Minimum Useful Artifact
 
-- problem, users, and business or organizational goal
+- problem, users, and business or organizational goal (toolkit: goal is first successful clone, not revenue)
 - requirements, constraints, and explicit non-goals
 - audience, channel, and first successful use
-- one to three metrics with definition, target, and timeframe
+- one to three metrics with definition, target, and timeframe — or **unmeasured** / **N/A (toolkit)**
 - events that make each metric observable, or `unmeasured`
 - assumptions, open questions, and named decision owners
 
@@ -63,7 +65,7 @@ Do not invent TAM, LTV, or a fog of events to complete a template. An internal t
 
 ## Definition of Done
 
-Product intent is documented or explicitly deferred with named owners. Implementation aligns with stated goals and non-goals, or the docs were updated. Success that was claimed is either instrumented or marked unmeasured.
+This station’s product artifact is documented or explicitly deferred with named owners. Implementation aligns with stated goals and non-goals, or the docs were updated. Success that was claimed is either instrumented or marked unmeasured. This is not “the whole repository is done.”
 
 ## Agent Prompt
 

--- a/_first/principles/QUALITY.md
+++ b/_first/principles/QUALITY.md
@@ -52,7 +52,7 @@ Choose the mechanism that matches the output. Deterministic code gets tests. Mod
 
 ## Definition of Done
 
-Stated quality criteria are met and verified by the project's existing validation. Regressions are caught or explicitly accepted with documented rationale.
+This station’s stated quality criteria are met and verified by the project's existing validation. Regressions are caught or explicitly accepted with documented rationale. CI going green is Pipelines. This is not Product success after use.
 
 ## Agent Prompt
 


### PR DESCRIPTION
## Summary
- `.cursor/README.md` points at `.agents/skills/` (there is no `.cursor/skills/`). FIRST load order is linked from `_first/README.md`.
- `_first/articles/` pointer stubs resolve `principles/` Navigation links without vendoring the full essays. Product brief is unchanged.

## Test plan
- [ ] Open `.cursor/README.md` links
- [ ] Open `_first/principles/PRODUCT.md` Human essay link