### PR TITLE
docs(workflow): vendor persist destinations and FIRST map

### DIFF
--- a/.agents/skills/workflow/add-documentation/SKILL.md
+++ b/.agents/skills/workflow/add-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-documentation
-description: Add comprehensive documentation for current code/feature per project standards (README, apps/docu website, or inline comments). Use when the user types /add-documentation.
+description: Add comprehensive documentation for current code/feature per project standards (README, docs site, or inline comments). Use when the user types /add-documentation.
 disable-model-invocation: true
 ---
 
@@ -10,13 +10,17 @@ Add documentation for the current code/feature. Follow `.cursor/rules/base/docs.
 
 | Layer | Role | Update when |
 | --- | --- | --- |
-| `apps/docu/content/docs/` MDX | Architecture, ADRs, how-to | Behavior, architecture, commands, conventions, or workflow changed |
+| `apps/docu/content/docs/product/` | Intent, feature map, roadmap | Goals, shipped vs intended, horizons changed |
+| `apps/docu/content/docs/` other MDX | Architecture, ADRs, how-to, Product Ready | Behavior, architecture, commands, conventions, or workflow changed |
+| GitHub Issues | Backlog | Later bets and work items — not `__dev/`, not `BACKLOG.md` |
+| `__dev/` | Scratch | Notes that have not graduated. Not Fact |
 | `.cursor/rules` | Short constraints | A convention the agent must not violate changed |
 | Nearest README | How to run this app/package; links only | Scripts, setup, or package purpose changed |
 
-Inline comments only when the code is otherwise misleading. Do not copy MDX into rules or READMEs. Do not `@`-attach MDX.
+Inline comments only when the code is otherwise misleading. Do not copy MDX into rules or READMEs. Do not `@`-attach MDX. There is no 13th FIRST station and no root `PRODUCT.md` / `ROADMAP.md`.
 
 1. **Identify the topic**: Matching docs section, then existing topic page (create a page only if none fits)
 2. **Write or patch MDX** if the canonical explanation changed
 3. **Patch README** only for run/setup/scripts; link the MDX
 4. **Patch the glob-matched `.mdc`** only if a constraint changed
+5. **Open or update a GitHub Issue** if the item is backlog, not documentation

--- a/.agents/skills/workflow/council/SKILL.md
+++ b/.agents/skills/workflow/council/SKILL.md
@@ -9,4 +9,4 @@ Based on the given area of interest, dig around the codebase to gather informati
 1. **Gather information**: Dig around the codebase in terms of given area of interest, gather general information such as keywords and architecture overview
 2. **Spawn task agents**: Spawn off n=10 (unless specified otherwise) task agents to dig deeper into the codebase, some should be out of the box for variance
 3. **Use information**: Once the task agents are done, use the information to do what the user wants (if user is in plan mode, create the plan per @.cursor/rules/base/general.mdc: References, assumptions, deferrals)
-
+4. **Persist**: If the user asked for a plan, keep it in the Cursor plan. If the finding changes product, quality, or workflow facts, patch the matching MDX or FIRST overlay in the same later implementation — not `__dev/` as Fact. Issues for later work go to GitHub Issues.

--- a/.agents/skills/workflow/plan-feature/SKILL.md
+++ b/.agents/skills/workflow/plan-feature/SKILL.md
@@ -7,11 +7,12 @@ disable-model-invocation: true
 Systematically set up new feature from planning through implementation structure.
 
 1. **List goals first**: Capture and display feature goals at the outset for user alignment before any planning. Output a ## Goals section (3–7 bullets) summarizing scope, success criteria, and constraints. Confirm or adjust with user before proceeding.
-2. **Gather context**: Matching glob rule and skill, then **Read** the topic MDX under `apps/docu/content/docs/`. Rules override skills.
+2. **Gather context**: Matching glob rule and skill, then **Read** the topic MDX under `apps/docu/content/docs/` (or this repo’s docs path). Rules override skills. FIRST: `_first/AGENTS.md` → `_first/ABOUT.md` → `_first/FIRST.md` → principle → instance.
 3. **Define requirements**: Clarify scope, identify user stories/acceptance criteria, plan technical approach
 4. **Summarize assumptions**: List 3–5 bullets before detailed planning
 5. **Create feature branch**: Branch from main/develop, set up local dev, configure dependencies
 6. **Plan architecture**: Design data models/APIs, plan UI components/flow, consider testing strategy, document requirements
 7. **Add diagrams**: For architecture, data flow, or component relationships, generate Mermaid diagrams. Use `flowchart` (process flows), `sequenceDiagram` (API/request flows), `classDiagram` (structures), `erDiagram` (DB schemas), `stateDiagram-v2` (lifecycles). Clear labels, subgraphs for grouping, wrap in mermaid code blocks. Split into multiple diagrams if complex.
 8. **Output structure**: ## Goals first, then body, then ## References. List paths to each rule, skill, and MDX page used (plain paths, no `@`). Example: `apps/docu/content/docs/architecture/api.mdx`, `.cursor/rules/backend/fastify.mdc`, `.agents/skills/fastify-v5`.
-9. **Defer when uncertain**: Ask questions when in doubt; defer to user for ambiguous, high-risk decisions
+9. **Persist**: Keep the Cursor plan file as the working brief. If the change names product intent, also patch `apps/docu/content/docs/product/` (or the path in `_first/FIRST.md`) in the same implementation PR. Do not put the plan only in `__dev/` or chat. Backlog items go to GitHub Issues, not `BACKLOG.md`.
+10. **Defer when uncertain**: Ask questions when in doubt; defer to user for ambiguous, high-risk decisions

--- a/.agents/skills/workflow/retro/SKILL.md
+++ b/.agents/skills/workflow/retro/SKILL.md
@@ -8,10 +8,10 @@ Answer this question about the work just completed (this session, the last plan,
 
 anything you would do better in retrospect ?
 
-Reply in chat only—never create files unless the user asks to apply a change.
+Reply in chat first. Then, if a decision or convention changed, **update the same-change files** (matching MDX, nearest README, FIRST overlay) in a follow-up the user can accept. Never leave a load-bearing lesson only in chat or `__dev/`.
 
 1. **Scope**: The work that just shipped or the plan just executed—not a career retrospective, not a generic process lecture
 2. **Be specific**: Name files, APIs, grep patterns, leftover folders, APIs you taught vs what the app still calls. Skip items that were the right call
 3. **Actionable**: Each item implies a different next action (rewrite, delete, document, don't migrate). If you would not change it, omit it
 4. **Honest**: Include mistakes (broken snippets, substring grep, hunting dirs that were already gone)
-5. **Short**: A few bullets. No preamble. Do not offer to implement unless asked
+5. **Short**: A few bullets. No preamble. Offer to patch durable files; do not implement a rewrite unless asked

--- a/.agents/skills/workflow/roadmap/SKILL.md
+++ b/.agents/skills/workflow/roadmap/SKILL.md
@@ -4,12 +4,13 @@ description: Analyze codebase and generate visual roadmap of potential features 
 disable-model-invocation: true
 ---
 
-Analyze codebase and generate visual roadmap of potential features and improvements. Track progress with todos.
+Analyze codebase and generate a visual roadmap of potential features and improvements. Track progress with todos.
 
-1. **Scan codebase**: Scan codebase architecture, patterns, conventions, look for opportunities (missing common patterns, performance optimization opportunities, developer experience improvements, user-facing feature enhancements, code quality/refactoring candidates)
-2. **Identify opportunities**: Identify feature gaps and improvement opportunities
-3. **Create timeline diagram**: Create phased overview showing features by effort level (Quick Wins, Medium Effort, Strategic)
-4. **Create current vs proposed flowchart**: Show integration points (solid borders for existing features, dashed orange borders for proposed features)
-5. **Ask user**: Ask "Would you like me to create a plan for any of these features?" (plans follow @.cursor/rules/base/general.mdc: References, assumptions, deferrals)
-6. **Output**: Render directly in chat (don't write files) - brief assessment of current codebase state, prioritized feature list (5-8 items with rationale), timeline diagram, current vs proposed flowchart
+Canonical horizon file in Basilic: `apps/docu/content/docs/product/roadmap.mdx`. Backlog = GitHub Issues. `__dev/` is scratch.
 
+1. **Scan codebase**: Scan architecture, patterns, conventions; look for opportunities (missing patterns, performance, DX, user-facing features, refactors)
+2. **Identify opportunities**: Feature gaps and improvements. Separate R0 / R-demo / later / not-now using the existing roadmap if present
+3. **Create timeline diagram**: Phased overview (Quick Wins, Medium Effort, Strategic)
+4. **Create current vs proposed flowchart**: Solid borders for existing, dashed for proposed
+5. **Ask user**: Ask whether to update `product/roadmap.mdx` and/or open GitHub Issues. Plans follow @.cursor/rules/base/general.mdc (References, assumptions, deferrals)
+6. **Output**: Show the assessment in chat. **Write** `apps/docu/content/docs/product/roadmap.mdx` when the user confirms a durable horizon change. Do not leave the roadmap only in chat. Do not write `ROADMAP.md` at repo root. Do not treat `__dev/` as the roadmap.

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -5,14 +5,15 @@ Rules, skills, and MCP for AI-assisted development. Daily workflow: [AI Developm
 ## Layout
 
 - [`rules/`](rules/) — constraints. Glob-scoped except `base/general.mdc`, `base/naming.mdc`, `base/git.mdc`, `base/file-organization.mdc` (always on).
-- [`skills/`](skills/) — on-demand expertise (`<topic>-v<major>/`) and slash playbooks under `workflow/`. Refresh: `pnpm dlx skills@latest add blockmatic/basilic-skills` ([Cursor Skills](../apps/docu/content/docs/development/cursor-skills.mdx)). Catalog: [blockmatic/basilic-skills](https://github.com/blockmatic/basilic-skills).
+- [`.agents/skills/`](../.agents/skills/) — on-demand expertise (`<topic>-v<major>/`) and slash playbooks under `workflow/`. Refresh: `pnpm dlx skills@latest add blockmatic/basilic-skills` ([Cursor Skills](../apps/docu/content/docs/development/cursor-skills.mdx)). Catalog: [blockmatic/basilic-skills](https://github.com/blockmatic/basilic-skills). There is no `.cursor/skills/` tree in this repo.
 - [`mcp.json`](mcp.json) — MCP servers. Setup: [Cursor Setup](../apps/docu/content/docs/development/cursor-setup.mdx).
 
-Type `/` in chat for playbooks (`/plan-feature`, `/exec-push`, `/git-commit`, `/retro`). Tech skills load when relevant, or `@.agents/skills/<name>`.
+Type `/` in chat for playbooks (`/plan-feature`, `/git-create-pr`, `/git-commit`, `/retro`). Tech skills load when relevant, or `@.agents/skills/<name>`.
 
 ## Related
 
 - [AI Workflow](https://basilic-docs.vercel.app/docs/development/ai-workflow)
+- FIRST: [`_first/README.md`](../_first/README.md) — load `_first/AGENTS.md` then `_first/ABOUT.md` then `_first/FIRST.md`
 - [Cursor Setup](https://basilic-docs.vercel.app/docs/development/cursor-setup)
 - [Cursor Skills](https://basilic-docs.vercel.app/docs/development/cursor-skills)
 - [Cursor rules](https://cursor.com/docs/context/rules) · [skills](https://cursor.com/docs/context/skills)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,6 @@ This repository uses **Cursor-native** AI workflows. Do not run a parallel proce
 - `.cursor/rules/` — constraints (override skills)
 - `.agents/skills/` — tech patterns (`<topic>-v<major>/`) and slash playbooks under `workflow/`; install/refresh via `pnpm dlx skills@latest add blockmatic/basilic-skills` (see [Cursor Skills](apps/docu/content/docs/development/cursor-skills.mdx)). Catalog: [`blockmatic/basilic-skills`](https://github.com/blockmatic/basilic-skills)
 - `apps/docu/content/docs/` — architecture, ADRs, how-to
-- FIRST: `_first/AGENTS.md` then `_first/FIRST.md`; then `_first/principles/X.md` and the instance path listed in FIRST.md. Factory source: [`blockmatic/first`](https://github.com/blockmatic/first).
+- FIRST: `_first/AGENTS.md` then `_first/ABOUT.md` then `_first/FIRST.md`; then `_first/principles/X.md` and the instance path listed in FIRST.md. Factory source: [`blockmatic/first`](https://github.com/blockmatic/first).
 
 Details: `apps/docu/content/docs/development/ai-workflow.mdx`.

--- a/_first/ABOUT.md
+++ b/_first/ABOUT.md
@@ -1,7 +1,7 @@
 # First Principles
 
 Version: 0.2-draft  
-Last reviewed: 2026-09-03
+Last reviewed: 2026-09-04
 
 Some decisions are too consequential to become afterthoughts. Important project knowledge should live in files, not disappear into conversations.
 
@@ -13,6 +13,13 @@ This is an agent-first factory, not an agent-autonomous one. Humans still decide
 
 - **Users of the framework** — adopting FIRST in a product repo. Copy the user pack into `_first/`. Edit [FIRST.md](FIRST.md) and opted-in station files. Merge a pointer into root `AGENTS.md`.
 - **Maintainers of the framework** — evolving FIRST itself. Start at [`blockmatic/first` maintainers](https://github.com/blockmatic/first/blob/main/_first/maintainers/README.md). Do not copy `maintainers/` or `instance/`.
+
+## Dual audience (minimum)
+
+- **User of the framework:** copy the user pack, write `FIRST.md`, keep product facts in instance files or docs those files point at.
+- **Maintainer of the framework:** edit `principles/`, `articles/`, `maintainers/`, and `packages/validate`. Do not encode one adopter’s product into generic files.
+
+Each principle’s **Definition of Done** is that station’s artifact. It is not the whole factory, not CI green, and not Product success after use. Quality / Product / Pipelines qualify “done” differently — see Boundaries below.
 
 ## Audiences
 

--- a/_first/README.md
+++ b/_first/README.md
@@ -23,7 +23,7 @@ cp ../first/_first/ABOUT.md _first/ABOUT.md
 rsync -a --delete ../first/_first/principles/ _first/principles/
 ```
 
-Or copy those paths from a tagged `first` release. Skip `instance/` and `maintainers/`. Essays are optional; this repo links to them on the FIRST site instead of vendoring `articles/`.
+Or copy those paths from a tagged `first` release. Skip `instance/` and `maintainers/`. Essays are not fully vendored: `_first/articles/` holds pointer stubs so principle Navigation links resolve. The arguments live on [GitHub](https://github.com/blockmatic/first/tree/main/_first/articles).
 
 ## Human door
 

--- a/_first/articles/API.md
+++ b/_first/articles/API.md
@@ -1,0 +1,5 @@
+# API
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/API.md
+
+Do not treat this stub as the argument. It exists so `principles/API.md` local links resolve.

--- a/_first/articles/ARCHITECTURE.md
+++ b/_first/articles/ARCHITECTURE.md
@@ -1,0 +1,5 @@
+# ARCHITECTURE
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/ARCHITECTURE.md
+
+Do not treat this stub as the argument. It exists so `principles/ARCHITECTURE.md` local links resolve.

--- a/_first/articles/DATA.md
+++ b/_first/articles/DATA.md
@@ -1,0 +1,5 @@
+# DATA
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/DATA.md
+
+Do not treat this stub as the argument. It exists so `principles/DATA.md` local links resolve.

--- a/_first/articles/DESIGN.md
+++ b/_first/articles/DESIGN.md
@@ -1,0 +1,5 @@
+# DESIGN
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/DESIGN.md
+
+Do not treat this stub as the argument. It exists so `principles/DESIGN.md` local links resolve.

--- a/_first/articles/DOCUMENTATION.md
+++ b/_first/articles/DOCUMENTATION.md
@@ -1,0 +1,5 @@
+# DOCUMENTATION
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/DOCUMENTATION.md
+
+Do not treat this stub as the argument. It exists so `principles/DOCUMENTATION.md` local links resolve.

--- a/_first/articles/JOURNEYS.md
+++ b/_first/articles/JOURNEYS.md
@@ -1,0 +1,5 @@
+# JOURNEYS
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/JOURNEYS.md
+
+Do not treat this stub as the argument. It exists so `principles/JOURNEYS.md` local links resolve.

--- a/_first/articles/OPERATIONS.md
+++ b/_first/articles/OPERATIONS.md
@@ -1,0 +1,5 @@
+# OPERATIONS
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/OPERATIONS.md
+
+Do not treat this stub as the argument. It exists so `principles/OPERATIONS.md` local links resolve.

--- a/_first/articles/PIPELINES.md
+++ b/_first/articles/PIPELINES.md
@@ -1,0 +1,5 @@
+# PIPELINES
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/PIPELINES.md
+
+Do not treat this stub as the argument. It exists so `principles/PIPELINES.md` local links resolve.

--- a/_first/articles/PRODUCT.md
+++ b/_first/articles/PRODUCT.md
@@ -1,0 +1,5 @@
+# PRODUCT
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/PRODUCT.md
+
+Do not treat this stub as the argument. It exists so `principles/PRODUCT.md` local links resolve.

--- a/_first/articles/QUALITY.md
+++ b/_first/articles/QUALITY.md
@@ -1,0 +1,5 @@
+# QUALITY
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/QUALITY.md
+
+Do not treat this stub as the argument. It exists so `principles/QUALITY.md` local links resolve.

--- a/_first/articles/SECURITY.md
+++ b/_first/articles/SECURITY.md
@@ -1,0 +1,5 @@
+# SECURITY
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/SECURITY.md
+
+Do not treat this stub as the argument. It exists so `principles/SECURITY.md` local links resolve.

--- a/_first/articles/WORKFLOW.md
+++ b/_first/articles/WORKFLOW.md
@@ -1,0 +1,5 @@
+# WORKFLOW
+
+Essay (not vendored): https://github.com/blockmatic/first/blob/main/_first/articles/WORKFLOW.md
+
+Do not treat this stub as the argument. It exists so `principles/WORKFLOW.md` local links resolve.

--- a/_first/basilic/README.md
+++ b/_first/basilic/README.md
@@ -63,3 +63,8 @@ From a station file in this folder:
 | 12 | Operations | [OPERATIONS.md](OPERATIONS.md) |
 
 Do not invent TAM, event taxonomies, or SLOs to complete a template. Label **Fact**, **Drift**, and **Unresolved** under Artifacts.
+
+## Overlay as delta
+
+Keep the required `##` headings. Fill Artifacts with pointers and facts. Do **not** paste the generic Recipe, Agent Prompt, or Statement from `../principles/X.md`. Canonical briefs live in `apps/docu`. `__dev/` is scratch until it graduates into docs or this overlay.
+

--- a/_first/principles/DOCUMENTATION.md
+++ b/_first/principles/DOCUMENTATION.md
@@ -54,7 +54,9 @@ Public documentation may include `llms.txt` as a selective, machine-readable ori
 
 ## Definition of Done
 
-Durable context is written, accurate, and discoverable. Documentation drift is resolved or explicitly tracked. Future work will not need to rediscover what was already decided.
+This station’s durable context is written, accurate, and discoverable. Documentation drift is resolved or explicitly tracked. Future work will not need to rediscover what was already decided. This is not “CI is green.”
+
+Scratch (`__dev/` or chat) **graduates** when a decision must survive a new session: write it into the canonical doc (or an ADR) in the same change. Do not leave load-bearing Fact only in gitignored scratch.
 
 ## Agent Prompt
 

--- a/_first/principles/PRODUCT.md
+++ b/_first/principles/PRODUCT.md
@@ -31,14 +31,16 @@ When the product is a business, also:
 - Runway / burn / time to breakeven when the product is the company
 - AARRR as a prompt for acquisition through revenue, not a mandatory scorecard
 
+When the product is a **toolkit or starter** (fork-and-run, not a billed SaaS), skip TAM, LTV, CAC, and AARRR. Write **N/A (toolkit)** once. Do not invent a marketplace to complete the template.
+
 Do not invent TAM, LTV, or a fog of events to complete a template. An internal tool may have none of the finance fields. Then say so.
 
 ## Minimum Useful Artifact
 
-- problem, users, and business or organizational goal
+- problem, users, and business or organizational goal (toolkit: goal is first successful clone, not revenue)
 - requirements, constraints, and explicit non-goals
 - audience, channel, and first successful use
-- one to three metrics with definition, target, and timeframe
+- one to three metrics with definition, target, and timeframe — or **unmeasured** / **N/A (toolkit)**
 - events that make each metric observable, or `unmeasured`
 - assumptions, open questions, and named decision owners
 
@@ -63,7 +65,7 @@ Do not invent TAM, LTV, or a fog of events to complete a template. An internal t
 
 ## Definition of Done
 
-Product intent is documented or explicitly deferred with named owners. Implementation aligns with stated goals and non-goals, or the docs were updated. Success that was claimed is either instrumented or marked unmeasured.
+This station’s product artifact is documented or explicitly deferred with named owners. Implementation aligns with stated goals and non-goals, or the docs were updated. Success that was claimed is either instrumented or marked unmeasured. This is not “the whole repository is done.”
 
 ## Agent Prompt
 

--- a/_first/principles/QUALITY.md
+++ b/_first/principles/QUALITY.md
@@ -52,7 +52,7 @@ Choose the mechanism that matches the output. Deterministic code gets tests. Mod
 
 ## Definition of Done
 
-Stated quality criteria are met and verified by the project's existing validation. Regressions are caught or explicitly accepted with documented rationale.
+This station’s stated quality criteria are met and verified by the project's existing validation. Regressions are caught or explicitly accepted with documented rationale. CI going green is Pipelines. This is not Product success after use.
 
 ## Agent Prompt
 

--- a/apps/docu/content/docs/development/ai-workflow.mdx
+++ b/apps/docu/content/docs/development/ai-workflow.mdx
@@ -7,7 +7,11 @@ Development is **Cursor-first**. Claude Code follows the same rules and skills v
 
 Judgment lives in planning and review. Implementation is incremental. See [Engineering in the AI Era](https://gaboesquivel.com/blog/2026-02-engineering-ai-era). Index this site once — [Cursor Setup](/docs/development/cursor-setup). Versioning and how to update skills: [Cursor Skills](/docs/development/cursor-skills).
 
-FIRST is vendored from [`blockmatic/first`](https://github.com/blockmatic/first). Copy `AGENTS.md`, `ABOUT.md`, and `principles/` into `_first/`; keep `FIRST.md` and `_first/basilic/` as this repo’s instance. Essays live on the FIRST site, not in this tree. Agents load `_first/AGENTS.md`, then `_first/ABOUT.md`, then `_first/FIRST.md`, then this repository's instructions and skills, then `_first/principles/X.md` for the station in scope, then the instance listed in FIRST.md. FIRST is a documentation artifact; it does not replace this repository's Cursor-first workflow. Factory validation (`pnpm validate`) runs in the first repo.
+FIRST is vendored from [`blockmatic/first`](https://github.com/blockmatic/first). Copy `AGENTS.md`, `ABOUT.md`, and `principles/` into `_first/`; keep `FIRST.md` and `_first/basilic/` as this repo’s instance. Essays live on the FIRST site, not in this tree. Agents load `_first/AGENTS.md`, then `_first/ABOUT.md`, then `_first/FIRST.md`, then this repository's instructions and skills, then `_first/principles/X.md` for the station in scope, then the instance listed in FIRST.md. FIRST is a documentation artifact; it does not replace this repository's Cursor-first workflow. Factory validation (`pnpm validate`) runs in the first repo. There is **no FIRST skill** under `.agents/`.
+
+## FIRST stations
+
+Product, Journeys, Design, Architecture, Data, API, Documentation, Workflow, Pipelines, Quality, Security, Operations. Pick one primary station. Overlays are deltas in `_first/basilic/`. Durable product facts: `apps/docu/content/docs/product/`.
 
 ## Sources of truth
 


### PR DESCRIPTION
## Summary
- `ai-workflow.mdx` lists FIRST stations above the guidance hierarchy. No FIRST skill under `.agents/`.
- Vendors `/plan-feature`, `/council`, `/roadmap`, `/retro`, and `/add-documentation` from [blockmatic/basilic-skills#5](https://github.com/blockmatic/basilic-skills/pull/5).

## Test plan
- [ ] FIRST section sits above the hierarchy table
- [ ] `/roadmap` skill no longer says chat-only